### PR TITLE
Perf: DataContext centralizado + persistencia local Firestore (#17)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { DataProvider } from '@/contexts/DataContext';
 import { LoginForm } from '@/components/auth/LoginForm';
 import { PrivateRoute } from '@/components/auth/PrivateRoute';
 import { Layout } from '@/components/layout/Layout';
@@ -22,7 +23,9 @@ function App() {
             path="/"
             element={
               <PrivateRoute>
-                <Layout />
+                <DataProvider>
+                  <Layout />
+                </DataProvider>
               </PrivateRoute>
             }
           >

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -3,6 +3,7 @@ import {
   collection,
   query,
   where,
+  orderBy,
   getDocs,
   Timestamp,
   type DocumentData,
@@ -166,6 +167,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         collection(db, 'payment_instances'),
         where('householdId', '==', householdId),
         where('dueDate', '>=', Timestamp.fromDate(startDate)),
+        orderBy('dueDate', 'asc'),
       );
       const snapshot = await getDocs(q);
       const data = snapshot.docs.map((doc) => {

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,10 +1,13 @@
-import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import {
   collection,
   query,
   where,
   getDocs,
   Timestamp,
+  type DocumentData,
+  type QueryConstraint,
+  type QueryDocumentSnapshot,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/contexts/AuthContext';
@@ -17,6 +20,8 @@ import type {
   PaymentInstance,
 } from '@/lib/types';
 
+type DataErrorKey = 'cards' | 'banks' | 'services' | 'serviceLines' | 'scheduledPayments' | 'paymentInstances';
+
 interface DataContextType {
   cards: Card[];
   banks: Bank[];
@@ -25,7 +30,7 @@ interface DataContextType {
   scheduledPayments: ScheduledPayment[];
   paymentInstances: PaymentInstance[];
   loading: boolean;
-  errors: Record<string, string | null>;
+  errors: Record<DataErrorKey, string | null>;
   refetchCards: () => Promise<void>;
   refetchBanks: () => Promise<void>;
   refetchServices: () => Promise<void>;
@@ -45,6 +50,26 @@ export function useData() {
   return context;
 }
 
+// Mapeo base de documento Firestore a entidad con campos de metadata
+function mapDoc<T>(doc: QueryDocumentSnapshot<DocumentData>): T {
+  const d = doc.data();
+  return {
+    ...d,
+    id: doc.id,
+    createdAt: d.createdAt?.toDate() || new Date(),
+    updatedAt: d.updatedAt?.toDate() || new Date(),
+  } as T;
+}
+
+const INITIAL_ERRORS: Record<DataErrorKey, string | null> = {
+  cards: null,
+  banks: null,
+  services: null,
+  serviceLines: null,
+  scheduledPayments: null,
+  paymentInstances: null,
+};
+
 export function DataProvider({ children }: { children: React.ReactNode }) {
   const { currentUser } = useAuth();
   const householdId = currentUser?.householdId ?? null;
@@ -56,111 +81,78 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
   const [scheduledPayments, setScheduledPayments] = useState<ScheduledPayment[]>([]);
   const [paymentInstances, setPaymentInstances] = useState<PaymentInstance[]>([]);
   const [loading, setLoading] = useState(true);
-  const [errors, setErrors] = useState<Record<string, string | null>>({});
+  const [errors, setErrors] = useState<Record<DataErrorKey, string | null>>(INITIAL_ERRORS);
 
-  const setError = useCallback((key: string, error: string | null) => {
-    setErrors(prev => ({ ...prev, [key]: error }));
-  }, []);
+  // Helper generico para fetch de colecciones simples
+  async function fetchCollection<T>(
+    hId: string,
+    collectionName: string,
+    setter: (data: T[]) => void,
+    errorKey: DataErrorKey,
+    errorLabel: string,
+    mapFn: (doc: QueryDocumentSnapshot<DocumentData>) => T = mapDoc,
+    extraConstraints?: QueryConstraint[],
+  ) {
+    try {
+      const constraints: QueryConstraint[] = [
+        where('householdId', '==', hId),
+        ...(extraConstraints ?? []),
+      ];
+      const q = query(collection(db, collectionName), ...constraints);
+      const snapshot = await getDocs(q);
+      setter(snapshot.docs.map(mapFn));
+      setErrors(prev => prev[errorKey] === null ? prev : { ...prev, [errorKey]: null });
+    } catch (err) {
+      console.error(`Error fetching ${collectionName}:`, err);
+      setErrors(prev => ({ ...prev, [errorKey]: `Error al cargar ${errorLabel}` }));
+    }
+  }
 
   const fetchCards = useCallback(async () => {
     if (!householdId) return;
-    try {
-      const q = query(collection(db, 'cards'), where('householdId', '==', householdId));
-      const snapshot = await getDocs(q);
-      const data = snapshot.docs.map((doc) => ({
-        ...doc.data(),
+    await fetchCollection<Card>(householdId, 'cards', setCards, 'cards', 'tarjetas', (doc) => {
+      const d = doc.data();
+      return {
+        ...d,
         id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-        cardType: doc.data().cardType || 'Departamental',
-        owner: doc.data().owner || 'Gustavo',
-        bankId: doc.data().bankId || '',
-        availableCredit: doc.data().availableCredit || 0,
-      })) as Card[];
-      setCards(data);
-      setError('cards', null);
-    } catch (err) {
-      console.error('Error fetching cards:', err);
-      setError('cards', 'Error al cargar tarjetas');
-    }
-  }, [householdId, setError]);
+        createdAt: d.createdAt?.toDate() || new Date(),
+        updatedAt: d.updatedAt?.toDate() || new Date(),
+        cardType: d.cardType || 'Departamental',
+        owner: d.owner || 'Gustavo',
+        bankId: d.bankId || '',
+        availableCredit: d.availableCredit || 0,
+      } as Card;
+    });
+  }, [householdId]);
 
   const fetchBanks = useCallback(async () => {
     if (!householdId) return;
-    try {
-      const q = query(collection(db, 'banks'), where('householdId', '==', householdId));
-      const snapshot = await getDocs(q);
-      const data = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as Bank[];
-      setBanks(data);
-      setError('banks', null);
-    } catch (err) {
-      console.error('Error fetching banks:', err);
-      setError('banks', 'Error al cargar bancos');
-    }
-  }, [householdId, setError]);
+    await fetchCollection<Bank>(householdId, 'banks', setBanks, 'banks', 'bancos');
+  }, [householdId]);
 
   const fetchServices = useCallback(async () => {
     if (!householdId) return;
-    try {
-      const q = query(collection(db, 'services'), where('householdId', '==', householdId));
-      const snapshot = await getDocs(q);
-      const data = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as Service[];
-      setServices(data);
-      setError('services', null);
-    } catch (err) {
-      console.error('Error fetching services:', err);
-      setError('services', 'Error al cargar servicios');
-    }
-  }, [householdId, setError]);
+    await fetchCollection<Service>(householdId, 'services', setServices, 'services', 'servicios');
+  }, [householdId]);
 
   const fetchServiceLines = useCallback(async () => {
     if (!householdId) return;
-    try {
-      const q = query(collection(db, 'service_lines'), where('householdId', '==', householdId));
-      const snapshot = await getDocs(q);
-      const data = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as ServiceLine[];
-      setServiceLines(data);
-      setError('serviceLines', null);
-    } catch (err) {
-      console.error('Error fetching service lines:', err);
-      setError('serviceLines', 'Error al cargar lineas de servicio');
-    }
-  }, [householdId, setError]);
+    await fetchCollection<ServiceLine>(householdId, 'service_lines', setServiceLines, 'serviceLines', 'lineas de servicio');
+  }, [householdId]);
 
   const fetchScheduledPayments = useCallback(async () => {
     if (!householdId) return;
-    try {
-      const q = query(collection(db, 'scheduled_payments'), where('householdId', '==', householdId));
-      const snapshot = await getDocs(q);
-      const data = snapshot.docs.map((doc) => ({
-        ...doc.data(),
+    await fetchCollection<ScheduledPayment>(householdId, 'scheduled_payments', setScheduledPayments, 'scheduledPayments', 'pagos programados', (doc) => {
+      const d = doc.data();
+      return {
+        ...d,
         id: doc.id,
-        paymentDate: doc.data().paymentDate?.toDate(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as ScheduledPayment[];
-      setScheduledPayments(data);
-      setError('scheduledPayments', null);
-    } catch (err) {
-      console.error('Error fetching scheduled payments:', err);
-      setError('scheduledPayments', 'Error al cargar pagos programados');
-    }
-  }, [householdId, setError]);
+        paymentDate: d.paymentDate?.toDate(),
+        createdAt: d.createdAt?.toDate() || new Date(),
+        updatedAt: d.updatedAt?.toDate() || new Date(),
+      } as ScheduledPayment;
+    });
+  }, [householdId]);
 
   const fetchPaymentInstances = useCallback(async () => {
     if (!householdId) return;
@@ -176,65 +168,52 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         where('dueDate', '>=', Timestamp.fromDate(startDate)),
       );
       const snapshot = await getDocs(q);
-      let data = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        dueDate: doc.data().dueDate?.toDate() || new Date(),
-        paidDate: doc.data().paidDate?.toDate(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as PaymentInstance[];
+      const data = snapshot.docs.map((doc) => {
+        const d = doc.data();
+        return {
+          ...d,
+          id: doc.id,
+          dueDate: d.dueDate?.toDate() || new Date(),
+          paidDate: d.paidDate?.toDate(),
+          createdAt: d.createdAt?.toDate() || new Date(),
+          updatedAt: d.updatedAt?.toDate() || new Date(),
+        } as PaymentInstance;
+      });
 
       // Filtrar rango superior en cliente
-      data = data.filter(instance => instance.dueDate <= endDate);
-
-      setPaymentInstances(data);
-      setError('paymentInstances', null);
+      setPaymentInstances(data.filter(instance => instance.dueDate <= endDate));
+      setErrors(prev => prev.paymentInstances === null ? prev : { ...prev, paymentInstances: null });
     } catch (err) {
       console.error('Error fetching payment instances:', err);
-      setError('paymentInstances', 'Error al cargar instancias de pago');
+      setErrors(prev => ({ ...prev, paymentInstances: 'Error al cargar instancias de pago' }));
     }
-  }, [householdId, setError]);
+  }, [householdId]);
 
   const refetchAll = useCallback(async () => {
     if (!householdId) return;
     await Promise.allSettled([
-      fetchCards(),
-      fetchBanks(),
-      fetchServices(),
-      fetchServiceLines(),
-      fetchScheduledPayments(),
-      fetchPaymentInstances(),
+      fetchCards(), fetchBanks(), fetchServices(),
+      fetchServiceLines(), fetchScheduledPayments(), fetchPaymentInstances(),
     ]);
   }, [householdId, fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances]);
 
-  // Fetch inicial cuando householdId esta disponible
+  // Ref para evitar listar los 6 callbacks en el dep-array del efecto.
+  // householdId es la unica dependencia real; los callbacks son estables mientras no cambie.
+  const refetchAllRef = useRef(refetchAll);
+  refetchAllRef.current = refetchAll;
+
   useEffect(() => {
     if (!householdId) {
       setLoading(false);
       return;
     }
-
     setLoading(true);
-    Promise.allSettled([
-      fetchCards(),
-      fetchBanks(),
-      fetchServices(),
-      fetchServiceLines(),
-      fetchScheduledPayments(),
-      fetchPaymentInstances(),
-    ]).finally(() => setLoading(false));
-  }, [householdId, fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances]);
+    refetchAllRef.current().finally(() => setLoading(false));
+  }, [householdId]);
 
   const value: DataContextType = useMemo(() => ({
-    cards,
-    banks,
-    services,
-    serviceLines,
-    scheduledPayments,
-    paymentInstances,
-    loading,
-    errors,
+    cards, banks, services, serviceLines, scheduledPayments, paymentInstances,
+    loading, errors,
     refetchCards: fetchCards,
     refetchBanks: fetchBanks,
     refetchServices: fetchServices,

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,0 +1,252 @@
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  Timestamp,
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { useAuth } from '@/contexts/AuthContext';
+import type {
+  Card,
+  Bank,
+  Service,
+  ServiceLine,
+  ScheduledPayment,
+  PaymentInstance,
+} from '@/lib/types';
+
+interface DataContextType {
+  cards: Card[];
+  banks: Bank[];
+  services: Service[];
+  serviceLines: ServiceLine[];
+  scheduledPayments: ScheduledPayment[];
+  paymentInstances: PaymentInstance[];
+  loading: boolean;
+  errors: Record<string, string | null>;
+  refetchCards: () => Promise<void>;
+  refetchBanks: () => Promise<void>;
+  refetchServices: () => Promise<void>;
+  refetchServiceLines: () => Promise<void>;
+  refetchScheduledPayments: () => Promise<void>;
+  refetchPaymentInstances: () => Promise<void>;
+  refetchAll: () => Promise<void>;
+}
+
+const DataContext = createContext<DataContextType | undefined>(undefined);
+
+export function useData() {
+  const context = useContext(DataContext);
+  if (!context) {
+    throw new Error('useData must be used within a DataProvider');
+  }
+  return context;
+}
+
+export function DataProvider({ children }: { children: React.ReactNode }) {
+  const { currentUser } = useAuth();
+  const householdId = currentUser?.householdId ?? null;
+
+  const [cards, setCards] = useState<Card[]>([]);
+  const [banks, setBanks] = useState<Bank[]>([]);
+  const [services, setServices] = useState<Service[]>([]);
+  const [serviceLines, setServiceLines] = useState<ServiceLine[]>([]);
+  const [scheduledPayments, setScheduledPayments] = useState<ScheduledPayment[]>([]);
+  const [paymentInstances, setPaymentInstances] = useState<PaymentInstance[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errors, setErrors] = useState<Record<string, string | null>>({});
+
+  const setError = useCallback((key: string, error: string | null) => {
+    setErrors(prev => ({ ...prev, [key]: error }));
+  }, []);
+
+  const fetchCards = useCallback(async () => {
+    if (!householdId) return;
+    try {
+      const q = query(collection(db, 'cards'), where('householdId', '==', householdId));
+      const snapshot = await getDocs(q);
+      const data = snapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+        cardType: doc.data().cardType || 'Departamental',
+        owner: doc.data().owner || 'Gustavo',
+        bankId: doc.data().bankId || '',
+        availableCredit: doc.data().availableCredit || 0,
+      })) as Card[];
+      setCards(data);
+      setError('cards', null);
+    } catch (err) {
+      console.error('Error fetching cards:', err);
+      setError('cards', 'Error al cargar tarjetas');
+    }
+  }, [householdId, setError]);
+
+  const fetchBanks = useCallback(async () => {
+    if (!householdId) return;
+    try {
+      const q = query(collection(db, 'banks'), where('householdId', '==', householdId));
+      const snapshot = await getDocs(q);
+      const data = snapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      })) as Bank[];
+      setBanks(data);
+      setError('banks', null);
+    } catch (err) {
+      console.error('Error fetching banks:', err);
+      setError('banks', 'Error al cargar bancos');
+    }
+  }, [householdId, setError]);
+
+  const fetchServices = useCallback(async () => {
+    if (!householdId) return;
+    try {
+      const q = query(collection(db, 'services'), where('householdId', '==', householdId));
+      const snapshot = await getDocs(q);
+      const data = snapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      })) as Service[];
+      setServices(data);
+      setError('services', null);
+    } catch (err) {
+      console.error('Error fetching services:', err);
+      setError('services', 'Error al cargar servicios');
+    }
+  }, [householdId, setError]);
+
+  const fetchServiceLines = useCallback(async () => {
+    if (!householdId) return;
+    try {
+      const q = query(collection(db, 'service_lines'), where('householdId', '==', householdId));
+      const snapshot = await getDocs(q);
+      const data = snapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      })) as ServiceLine[];
+      setServiceLines(data);
+      setError('serviceLines', null);
+    } catch (err) {
+      console.error('Error fetching service lines:', err);
+      setError('serviceLines', 'Error al cargar lineas de servicio');
+    }
+  }, [householdId, setError]);
+
+  const fetchScheduledPayments = useCallback(async () => {
+    if (!householdId) return;
+    try {
+      const q = query(collection(db, 'scheduled_payments'), where('householdId', '==', householdId));
+      const snapshot = await getDocs(q);
+      const data = snapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+        paymentDate: doc.data().paymentDate?.toDate(),
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      })) as ScheduledPayment[];
+      setScheduledPayments(data);
+      setError('scheduledPayments', null);
+    } catch (err) {
+      console.error('Error fetching scheduled payments:', err);
+      setError('scheduledPayments', 'Error al cargar pagos programados');
+    }
+  }, [householdId, setError]);
+
+  const fetchPaymentInstances = useCallback(async () => {
+    if (!householdId) return;
+    try {
+      // Filtro de fecha: 3 meses atras -> fin del mes siguiente
+      const now = new Date();
+      const startDate = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+      const endDate = new Date(now.getFullYear(), now.getMonth() + 2, 0, 23, 59, 59, 999);
+
+      const q = query(
+        collection(db, 'payment_instances'),
+        where('householdId', '==', householdId),
+        where('dueDate', '>=', Timestamp.fromDate(startDate)),
+      );
+      const snapshot = await getDocs(q);
+      let data = snapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+        dueDate: doc.data().dueDate?.toDate() || new Date(),
+        paidDate: doc.data().paidDate?.toDate(),
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      })) as PaymentInstance[];
+
+      // Filtrar rango superior en cliente
+      data = data.filter(instance => instance.dueDate <= endDate);
+
+      setPaymentInstances(data);
+      setError('paymentInstances', null);
+    } catch (err) {
+      console.error('Error fetching payment instances:', err);
+      setError('paymentInstances', 'Error al cargar instancias de pago');
+    }
+  }, [householdId, setError]);
+
+  const refetchAll = useCallback(async () => {
+    if (!householdId) return;
+    await Promise.allSettled([
+      fetchCards(),
+      fetchBanks(),
+      fetchServices(),
+      fetchServiceLines(),
+      fetchScheduledPayments(),
+      fetchPaymentInstances(),
+    ]);
+  }, [householdId, fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances]);
+
+  // Fetch inicial cuando householdId esta disponible
+  useEffect(() => {
+    if (!householdId) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    Promise.allSettled([
+      fetchCards(),
+      fetchBanks(),
+      fetchServices(),
+      fetchServiceLines(),
+      fetchScheduledPayments(),
+      fetchPaymentInstances(),
+    ]).finally(() => setLoading(false));
+  }, [householdId, fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances]);
+
+  const value: DataContextType = useMemo(() => ({
+    cards,
+    banks,
+    services,
+    serviceLines,
+    scheduledPayments,
+    paymentInstances,
+    loading,
+    errors,
+    refetchCards: fetchCards,
+    refetchBanks: fetchBanks,
+    refetchServices: fetchServices,
+    refetchServiceLines: fetchServiceLines,
+    refetchScheduledPayments: fetchScheduledPayments,
+    refetchPaymentInstances: fetchPaymentInstances,
+    refetchAll,
+  }), [
+    cards, banks, services, serviceLines, scheduledPayments, paymentInstances,
+    loading, errors,
+    fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances, refetchAll,
+  ]);
+
+  return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
+}

--- a/src/hooks/useBanks.ts
+++ b/src/hooks/useBanks.ts
@@ -1,14 +1,14 @@
-import { useFirestoreCollection } from './useFirestoreCollection';
+import { useMemo } from 'react';
+import { useData } from '@/contexts/DataContext';
 import type { Bank } from '@/lib/types';
 
-const sortByName = (data: Bank[]) => data.sort((a, b) => a.name.localeCompare(b.name));
-
 export function useBanks() {
-  const { data: banks, loading, error } = useFirestoreCollection<Bank>({
-    collectionName: 'banks',
-    transform: sortByName,
-    errorMessage: 'Error al cargar bancos'
-  });
+  const { banks: rawBanks, loading, errors, refetchBanks } = useData();
 
-  return { banks, loading, error };
+  const banks = useMemo(
+    () => [...rawBanks].sort((a: Bank, b: Bank) => a.name.localeCompare(b.name)),
+    [rawBanks]
+  );
+
+  return { banks, loading, error: errors.banks ?? null, refetch: refetchBanks };
 }

--- a/src/hooks/useServiceLines.ts
+++ b/src/hooks/useServiceLines.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useFirestoreCollection } from './useFirestoreCollection';
+import { useData } from '@/contexts/DataContext';
 import type { ServiceLine } from '@/lib/types';
 
 interface UseServiceLinesOptions {
@@ -9,9 +9,10 @@ interface UseServiceLinesOptions {
 
 export function useServiceLines(options: UseServiceLinesOptions = {}) {
   const { serviceId, activeOnly = true } = options;
+  const { serviceLines: rawServiceLines, loading, errors, refetchServiceLines } = useData();
 
-  const transform = useMemo(() => (data: ServiceLine[]): ServiceLine[] => {
-    let result = data;
+  const serviceLines = useMemo(() => {
+    let result = [...rawServiceLines];
 
     if (serviceId) {
       result = result.filter(line => line.serviceId === serviceId);
@@ -21,16 +22,10 @@ export function useServiceLines(options: UseServiceLinesOptions = {}) {
       result = result.filter(line => line.isActive);
     }
 
-    return result.sort((a, b) => a.name.localeCompare(b.name));
-  }, [serviceId, activeOnly]);
+    return result.sort((a: ServiceLine, b: ServiceLine) => a.name.localeCompare(b.name));
+  }, [rawServiceLines, serviceId, activeOnly]);
 
-  const { data: serviceLines, loading, error, refetch } = useFirestoreCollection<ServiceLine>({
-    collectionName: 'service_lines',
-    transform,
-    errorMessage: 'Error al cargar líneas de servicio'
-  });
-
-  return { serviceLines, loading, error, refetch };
+  return { serviceLines, loading, error: errors.serviceLines ?? null, refetch: refetchServiceLines };
 }
 
 export function useServiceLinesGrouped() {

--- a/src/hooks/useServiceLines.ts
+++ b/src/hooks/useServiceLines.ts
@@ -31,22 +31,16 @@ export function useServiceLines(options: UseServiceLinesOptions = {}) {
 export function useServiceLinesGrouped() {
   const { serviceLines, loading, error, refetch } = useServiceLines({ activeOnly: false });
 
-  const groupedByService = useMemo(() => {
-    return serviceLines.reduce((acc, line) => {
-      if (!acc[line.serviceId]) {
-        acc[line.serviceId] = [];
-      }
-      acc[line.serviceId].push(line);
-      return acc;
-    }, {} as Record<string, ServiceLine[]>);
+  const { groupedByService, linesCountByService } = useMemo(() => {
+    const grouped: Record<string, ServiceLine[]> = {};
+    const counts: Record<string, number> = {};
+    for (const line of serviceLines) {
+      if (!grouped[line.serviceId]) { grouped[line.serviceId] = []; counts[line.serviceId] = 0; }
+      grouped[line.serviceId].push(line);
+      if (line.isActive) counts[line.serviceId]++;
+    }
+    return { groupedByService: grouped, linesCountByService: counts };
   }, [serviceLines]);
-
-  const linesCountByService = useMemo(() => {
-    return Object.entries(groupedByService).reduce((acc, [serviceId, lines]) => {
-      acc[serviceId] = lines.filter(l => l.isActive).length;
-      return acc;
-    }, {} as Record<string, number>);
-  }, [groupedByService]);
 
   return {
     serviceLines,

--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -1,14 +1,14 @@
-import { useFirestoreCollection } from './useFirestoreCollection';
+import { useMemo } from 'react';
+import { useData } from '@/contexts/DataContext';
 import type { Service } from '@/lib/types';
 
-const sortByName = (data: Service[]) => data.sort((a, b) => a.name.localeCompare(b.name));
-
 export function useServices() {
-  const { data: services, loading, error } = useFirestoreCollection<Service>({
-    collectionName: 'services',
-    transform: sortByName,
-    errorMessage: 'Error al cargar servicios'
-  });
+  const { services: rawServices, loading, errors, refetchServices } = useData();
 
-  return { services, loading, error };
+  const services = useMemo(
+    () => [...rawServices].sort((a: Service, b: Service) => a.name.localeCompare(b.name)),
+    [rawServices]
+  );
+
+  return { services, loading, error: errors.services ?? null, refetch: refetchServices };
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -16,6 +16,8 @@ const app = initializeApp(firebaseConfig);
 
 // Initialize Firebase services
 export const auth = getAuth(app);
-export const db = getFirestore(app);
+export const db = initializeFirestore(app, {
+  localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }),
+});
 
 export default app;

--- a/src/pages/Banks.tsx
+++ b/src/pages/Banks.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import {
-  collection,
-  query,
-  where,
-  getDocs,
   addDoc,
   updateDoc,
   deleteDoc,
   doc,
+  collection,
   serverTimestamp,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/contexts/AuthContext';
+import { useData } from '@/contexts/DataContext';
 import { toast } from 'sonner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -29,8 +27,7 @@ import { Building2, Edit, Trash2, Plus, X, Search, Loader2 } from 'lucide-react'
 
 export function Banks() {
   const { currentUser } = useAuth();
-  const [banks, setBanks] = useState<Bank[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { banks, loading, refetchBanks } = useData();
   const [saving, setSaving] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingBank, setEditingBank] = useState<Bank | null>(null);
@@ -40,34 +37,6 @@ export function Banks() {
     name: '',
     code: '',
   });
-
-  useEffect(() => {
-    fetchBanks();
-  }, [currentUser?.householdId]);
-
-  const fetchBanks = async () => {
-    if (!currentUser) return;
-
-    try {
-      const banksQuery = query(
-        collection(db, 'banks'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(banksQuery);
-      const banksData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as Bank[];
-
-      setBanks(banksData);
-    } catch (error) {
-      console.error('Error fetching banks:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -101,7 +70,7 @@ export function Banks() {
       }
 
       resetForm();
-      await fetchBanks();
+      await refetchBanks();
     } catch (error) {
       console.error('Error saving bank:', error);
       toast.error('Error al guardar el banco');
@@ -126,7 +95,7 @@ export function Banks() {
       // TODO: Verificar que no haya tarjetas asociadas
       await deleteDoc(doc(db, 'banks', bankId));
       toast.success('Banco eliminado exitosamente');
-      await fetchBanks();
+      await refetchBanks();
     } catch (error) {
       console.error('Error deleting bank:', error);
       toast.error('Error al eliminar el banco');

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -64,8 +64,7 @@ import { formatCurrency } from '@/lib/utils';
 export function Cards() {
   const { currentUser } = useAuth();
   const { banks } = useBanks();
-  const { cards: contextCards, loading, refetchCards } = useData();
-  const [cards, setCards] = useState<CardType[]>([]);
+  const { cards, loading, refetchCards } = useData();
   const [saving, setSaving] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingCard, setEditingCard] = useState<CardType | null>(null);
@@ -126,11 +125,6 @@ export function Cards() {
   const [editingPayment, setEditingPayment] = useState<PaymentInstance | null>(null);
   const [partialAmount, setPartialAmount] = useState('');
   const [partialNotes, setPartialNotes] = useState('');
-
-  // Sincronizar cards del contexto al estado local
-  useEffect(() => {
-    setCards(contextCards);
-  }, [contextCards]);
 
   // Calcular automáticamente el saldo actual
   useEffect(() => {
@@ -200,14 +194,8 @@ export function Cards() {
         updatedByName: currentUser.name,
       });
 
-      // Actualizar estado local
-      setCards(prevCards =>
-        prevCards.map(card =>
-          card.id === cardId
-            ? { ...card, availableCredit: newAvailableCredit, currentBalance: newCurrentBalance }
-            : card
-        )
-      );
+      // Refrescar cards del contexto
+      await refetchCards();
 
       // Actualizar viewingCard si es la misma tarjeta
       if (viewingCard?.id === cardId) {

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -13,6 +13,7 @@ import {
   getDoc,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { useData } from '@/contexts/DataContext';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '@/contexts/AuthContext';
 import { useBanks } from '@/hooks/useBanks';
@@ -63,8 +64,8 @@ import { formatCurrency } from '@/lib/utils';
 export function Cards() {
   const { currentUser } = useAuth();
   const { banks } = useBanks();
+  const { cards: contextCards, loading, refetchCards } = useData();
   const [cards, setCards] = useState<CardType[]>([]);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingCard, setEditingCard] = useState<CardType | null>(null);
@@ -126,9 +127,10 @@ export function Cards() {
   const [partialAmount, setPartialAmount] = useState('');
   const [partialNotes, setPartialNotes] = useState('');
 
+  // Sincronizar cards del contexto al estado local
   useEffect(() => {
-    fetchCards();
-  }, [currentUser?.householdId]);
+    setCards(contextCards);
+  }, [contextCards]);
 
   // Calcular automáticamente el saldo actual
   useEffect(() => {
@@ -140,35 +142,6 @@ export function Cards() {
       }));
     }
   }, [formData.creditLimit, formData.availableCredit]);
-
-  const fetchCards = async () => {
-    if (!currentUser) return;
-
-    try {
-      const cardsQuery = query(
-        collection(db, 'cards'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(cardsQuery);
-      const cardsData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-        // Valores por defecto para campos nuevos
-        cardType: doc.data().cardType || 'Departamental',
-        owner: doc.data().owner || 'Gustavo',
-        bankId: doc.data().bankId || '',
-        availableCredit: doc.data().availableCredit || 0,
-      })) as CardType[];
-
-      setCards(cardsData.sort((a, b) => a.name.localeCompare(b.name)));
-    } catch (error) {
-      console.error('Error fetching cards:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const getStatusBadge = (status: PaymentStatus) => {
     const variants: Record<PaymentStatus, { variant: 'default' | 'secondary' | 'destructive', label: string }> = {
@@ -548,7 +521,7 @@ export function Cards() {
       }
 
       resetForm();
-      await fetchCards();
+      await refetchCards();
     } catch (error) {
       console.error('Error saving card:', error);
       toast.error('Error al guardar la tarjeta');
@@ -632,7 +605,7 @@ export function Cards() {
     try {
       await deleteDoc(doc(db, 'cards', cardId));
       toast.success('Tarjeta eliminada exitosamente');
-      await fetchCards();
+      await refetchCards();
     } catch (error) {
       console.error('Error deleting card:', error);
       toast.error('Error al eliminar la tarjeta');

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState, useMemo, useRef } from 'react';
-import { collection, query, where, getDocs } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { useEffect, useMemo, useRef } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useData } from '@/contexts/DataContext';
 import { useServices } from '@/hooks/useServices';
 import { useBanks } from '@/hooks/useBanks';
 import { useServiceLines } from '@/hooks/useServiceLines';
-import type { Card as CardType, PaymentInstance, ScheduledPayment } from '@/lib/types';
 import {
   calculateWeeklyCashFlow,
   analyzeCardPeriods,
@@ -25,14 +23,16 @@ import { staggerContainer, staggerItem } from '@/utils/animations';
 export function Dashboard() {
   const { currentUser } = useAuth();
   const householdId = currentUser?.householdId ?? null;
+  const {
+    cards,
+    paymentInstances,
+    scheduledPayments,
+    loading,
+    refetchPaymentInstances,
+  } = useData();
   const { services } = useServices();
   const { banks } = useBanks();
   const { serviceLines } = useServiceLines({ activeOnly: true });
-  const [cards, setCards] = useState<CardType[]>([]);
-  const [paymentInstances, setPaymentInstances] = useState<PaymentInstance[]>([]);
-  const [scheduledPayments, setScheduledPayments] = useState<ScheduledPayment[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [dataLoaded, setDataLoaded] = useState(false);
   const instancesGeneratedRef = useRef(false);
   const isGeneratingRef = useRef(false);
 
@@ -44,70 +44,9 @@ export function Dashboard() {
   const paymentInstancesRef = useRef(paymentInstances);
   paymentInstancesRef.current = paymentInstances;
 
-  useEffect(() => {
-    if (!householdId) return;
-
-    const fetchData = async () => {
-      try {
-        // Fetch cards
-        const cardsQuery = query(
-          collection(db, 'cards'),
-          where('householdId', '==', householdId)
-        );
-        const cardsSnapshot = await getDocs(cardsQuery);
-        const cardsData = cardsSnapshot.docs.map((doc) => ({
-          ...doc.data(),
-          id: doc.id,
-          createdAt: doc.data().createdAt?.toDate() || new Date(),
-          updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-        })) as CardType[];
-
-        // Fetch payment instances
-        const instancesQuery = query(
-          collection(db, 'payment_instances'),
-          where('householdId', '==', householdId)
-        );
-        const instancesSnapshot = await getDocs(instancesQuery);
-        const instancesData = instancesSnapshot.docs.map((doc) => ({
-          ...doc.data(),
-          id: doc.id,
-          dueDate: doc.data().dueDate?.toDate() || new Date(),
-          paidDate: doc.data().paidDate?.toDate(),
-          createdAt: doc.data().createdAt?.toDate() || new Date(),
-          updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-        })) as PaymentInstance[];
-
-        // Fetch scheduled payments
-        const scheduledQuery = query(
-          collection(db, 'scheduled_payments'),
-          where('householdId', '==', householdId)
-        );
-        const scheduledSnapshot = await getDocs(scheduledQuery);
-        const scheduledData = scheduledSnapshot.docs.map((doc) => ({
-          ...doc.data(),
-          id: doc.id,
-          paymentDate: doc.data().paymentDate?.toDate(),
-          createdAt: doc.data().createdAt?.toDate() || new Date(),
-          updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-        })) as ScheduledPayment[];
-
-        setCards(cardsData);
-        setPaymentInstances(instancesData);
-        setScheduledPayments(scheduledData);
-        setDataLoaded(true);
-      } catch (error) {
-        console.error('Error fetching data:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [householdId]);
-
   // Trigger: generar instancias faltantes del mes actual y siguiente
   useEffect(() => {
-    if (!householdId || loading || !dataLoaded || instancesGeneratedRef.current || isGeneratingRef.current) return;
+    if (!householdId || loading || instancesGeneratedRef.current || isGeneratingRef.current) return;
     if (scheduledPayments.length === 0) return;
 
     const generateMissingInstances = async () => {
@@ -121,6 +60,8 @@ export function Dashboard() {
           paymentInstancesRef.current
         );
         instancesGeneratedRef.current = true;
+        // Refetch para obtener instancias recién creadas
+        await refetchPaymentInstances();
       } catch (error: unknown) {
         const firebaseError = error as { message?: string; code?: string };
         console.error('[Dashboard] Error generando instancias:', firebaseError.code, firebaseError.message);
@@ -130,7 +71,7 @@ export function Dashboard() {
     };
 
     generateMissingInstances();
-  }, [householdId, loading, dataLoaded, scheduledPayments]);
+  }, [householdId, loading, scheduledPayments, refetchPaymentInstances]);
 
   // Rango de fechas fijo: mes actual
   const dateRange = useMemo(() => {

--- a/src/pages/PaymentCalendar.tsx
+++ b/src/pages/PaymentCalendar.tsx
@@ -104,8 +104,9 @@ export function PaymentCalendar() {
   const { banks } = useBanks();
   const { serviceLines: allServiceLines } = useServiceLines({ activeOnly: false });
   const [searchParams] = useSearchParams();
-  const [instances, setInstances] = useState<PaymentInstance[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Estado local solo para fetch independiente (timeFilter === 'all' o custom)
+  const [localInstances, setLocalInstances] = useState<PaymentInstance[]>([]);
+  const [localLoading, setLocalLoading] = useState(false);
   const [editingInstance, setEditingInstance] = useState<PaymentInstance | null>(null);
   const [showAdjustModal, setShowAdjustModal] = useState(false);
   const [adjustAmount, setAdjustAmount] = useState('');
@@ -124,16 +125,19 @@ export function PaymentCalendar() {
   const [customStartDate, setCustomStartDate] = useState<Date | null>(null);
   const [customEndDate, setCustomEndDate] = useState<Date | null>(null);
 
-  // Para filtros normales, usar instancias del contexto
-  // Para timeFilter === 'all', se hace fetch independiente (rango de 1 año)
+  // Determinar si necesitamos fetch independiente (rango extendido)
+  const needsLocalFetch = timeFilter === 'all' || (timeFilter === 'custom' && !!customStartDate);
+
+  // Variables derivadas: elegir entre datos locales o del contexto
+  const instances = needsLocalFetch ? localInstances : contextInstances;
+  const loading = needsLocalFetch ? localLoading : dataLoading;
+
+  // Solo hacer fetch independiente cuando el filtro lo requiere
   useEffect(() => {
-    if (timeFilter === 'all' || (timeFilter === 'custom' && customStartDate)) {
+    if (needsLocalFetch) {
       fetchInstances();
-    } else {
-      setInstances(contextInstances);
-      setLoading(dataLoading);
     }
-  }, [timeFilter, customStartDate, customEndDate, contextInstances, dataLoading, currentUser?.householdId]);
+  }, [needsLocalFetch, customStartDate, customEndDate, currentUser?.householdId]);
 
   // Calcular estado del ciclo vigente para cada línea de servicio
   const lineStatusMap = useMemo(() => {
@@ -239,7 +243,7 @@ export function PaymentCalendar() {
 
   const fetchInstances = async () => {
     if (!currentUser) return;
-
+    setLocalLoading(true);
     try {
       const now = new Date();
       let queryStartDate: Date;
@@ -290,11 +294,11 @@ export function PaymentCalendar() {
       // Ordenar por fecha
       instancesData.sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
 
-      setInstances(instancesData);
+      setLocalInstances(instancesData);
     } catch (error) {
       console.error('Error fetching instances:', error);
     } finally {
-      setLoading(false);
+      setLocalLoading(false);
     }
   };
 

--- a/src/pages/PaymentCalendar.tsx
+++ b/src/pages/PaymentCalendar.tsx
@@ -14,6 +14,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/contexts/AuthContext';
+import { useData } from '@/contexts/DataContext';
 import { useServices } from '@/hooks/useServices';
 import { useBanks } from '@/hooks/useBanks';
 import { useServiceLines } from '@/hooks/useServiceLines';
@@ -51,7 +52,6 @@ import type {
   PaymentInstance,
   Card as CardType,
   PartialPayment,
-  ScheduledPayment,
 } from '@/lib/types';
 import {
   Calendar,
@@ -92,13 +92,19 @@ const formatDateForInput = (date: Date): string => {
 
 export function PaymentCalendar() {
   const { currentUser } = useAuth();
+  const {
+    cards,
+    scheduledPayments,
+    paymentInstances: contextInstances,
+    loading: dataLoading,
+    refetchPaymentInstances,
+    refetchCards,
+  } = useData();
   const { services } = useServices();
   const { banks } = useBanks();
   const { serviceLines: allServiceLines } = useServiceLines({ activeOnly: false });
   const [searchParams] = useSearchParams();
   const [instances, setInstances] = useState<PaymentInstance[]>([]);
-  const [cards, setCards] = useState<CardType[]>([]);
-  const [scheduledPayments, setScheduledPayments] = useState<ScheduledPayment[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingInstance, setEditingInstance] = useState<PaymentInstance | null>(null);
   const [showAdjustModal, setShowAdjustModal] = useState(false);
@@ -118,16 +124,16 @@ export function PaymentCalendar() {
   const [customStartDate, setCustomStartDate] = useState<Date | null>(null);
   const [customEndDate, setCustomEndDate] = useState<Date | null>(null);
 
-  // Cards y scheduled_payments solo dependen del householdId
+  // Para filtros normales, usar instancias del contexto
+  // Para timeFilter === 'all', se hace fetch independiente (rango de 1 año)
   useEffect(() => {
-    fetchCards();
-    fetchScheduledPayments();
-  }, [currentUser?.householdId]);
-
-  // Instances dependen también de los filtros de fecha
-  useEffect(() => {
-    fetchInstances();
-  }, [currentUser?.householdId, timeFilter, customStartDate, customEndDate]);
+    if (timeFilter === 'all' || (timeFilter === 'custom' && customStartDate)) {
+      fetchInstances();
+    } else {
+      setInstances(contextInstances);
+      setLoading(dataLoading);
+    }
+  }, [timeFilter, customStartDate, customEndDate, contextInstances, dataLoading, currentUser?.householdId]);
 
   // Calcular estado del ciclo vigente para cada línea de servicio
   const lineStatusMap = useMemo(() => {
@@ -172,51 +178,6 @@ export function PaymentCalendar() {
     }
   }, [searchParams, instances, loading]);
 
-  const fetchCards = async () => {
-    if (!currentUser) return;
-
-    try {
-      const cardsQuery = query(
-        collection(db, 'cards'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(cardsQuery);
-      const cardsData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as CardType[];
-
-      setCards(cardsData);
-    } catch (error) {
-      console.error('Error fetching cards:', error);
-    }
-  };
-
-  const fetchScheduledPayments = async () => {
-    if (!currentUser) return;
-
-    try {
-      const paymentsQuery = query(
-        collection(db, 'scheduled_payments'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(paymentsQuery);
-      const paymentsData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-        paymentDate: doc.data().paymentDate?.toDate(),
-      })) as ScheduledPayment[];
-
-      setScheduledPayments(paymentsData);
-    } catch (error) {
-      console.error('Error fetching scheduled payments:', error);
-    }
-  };
-
   /**
    * Actualiza el crédito disponible de una tarjeta cuando se efectúa un pago
    * @param cardId - ID de la tarjeta a actualizar
@@ -260,16 +221,19 @@ export function PaymentCalendar() {
         updatedByName: currentUser.name,
       });
 
-      // Actualizar estado local
-      setCards(prevCards =>
-        prevCards.map(card =>
-          card.id === cardId
-            ? { ...card, availableCredit: newAvailableCredit, currentBalance: newCurrentBalance }
-            : card
-        )
-      );
+      // Refrescar cards del contexto
+      await refetchCards();
     } catch (error) {
       console.error('Error updating card available credit:', error);
+    }
+  };
+
+  // Después de mutaciones, refrescar instancias según el filtro activo
+  const refreshInstances = async () => {
+    if (timeFilter === 'all' || (timeFilter === 'custom' && customStartDate)) {
+      await fetchInstances();
+    } else {
+      await refetchPaymentInstances();
     }
   };
 
@@ -585,7 +549,7 @@ export function PaymentCalendar() {
       }
 
       toast.success('Pago marcado como realizado');
-      await fetchInstances();
+      await refreshInstances();
     } catch (error) {
       console.error('Error marking as paid:', error);
       toast.error('Error al marcar como pagado');
@@ -605,7 +569,7 @@ export function PaymentCalendar() {
       });
 
       toast.success('Pago cancelado');
-      await fetchInstances();
+      await refreshInstances();
     } catch (error) {
       console.error('Error cancelling payment:', error);
       toast.error('Error al cancelar el pago');
@@ -660,7 +624,7 @@ export function PaymentCalendar() {
         await updateCardAvailableCredit(instance.cardId, amountToRevert, 'subtract');
       }
 
-      await fetchInstances();
+      await refreshInstances();
     } catch (error) {
       console.error('Error unmarking as paid:', error);
       toast.error('Error al desmarcar como pagado');
@@ -739,7 +703,7 @@ export function PaymentCalendar() {
       }
       setShowAdjustModal(false);
       setEditingInstance(null);
-      await fetchInstances();
+      await refreshInstances();
     } catch (error) {
       console.error('Error adjusting amount:', error);
       toast.error('Error al ajustar el monto');
@@ -815,7 +779,7 @@ export function PaymentCalendar() {
       setEditingInstance(null);
       setPartialAmount('');
       setPartialNotes('');
-      await fetchInstances();
+      await refreshInstances();
     } catch (error) {
       console.error('Error saving partial payment:', error);
       toast.error('Error al registrar el pago parcial');
@@ -871,7 +835,7 @@ export function PaymentCalendar() {
       }
 
       toast.success('Pago parcial eliminado');
-      await fetchInstances();
+      await refreshInstances();
     } catch (error: any) {
       console.error('Error deleting partial payment:', error);
 
@@ -897,7 +861,7 @@ export function PaymentCalendar() {
           }
 
           toast.success('Pagos parciales limpiados (formato antiguo incompatible)');
-          await fetchInstances();
+          await refreshInstances();
           return;
         } catch (cleanupError) {
           console.error('Error cleaning up partial payments:', cleanupError);

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -120,7 +120,7 @@ export function Payments() {
   const { currentUser } = useAuth();
   const {
     cards,
-    scheduledPayments: contextScheduledPayments,
+    scheduledPayments: payments,
     paymentInstances,
     loading,
     refetchScheduledPayments,
@@ -130,7 +130,6 @@ export function Payments() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [returnToDashboard, setReturnToDashboard] = useState(false);
-  const [payments, setPayments] = useState<ScheduledPayment[]>([]);
   const [saving, setSaving] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingPayment, setEditingPayment] = useState<ScheduledPayment | null>(null);
@@ -177,11 +176,6 @@ export function Payments() {
   const [bankFilter, setBankFilter] = useState<string>('all');
   const [ownerFilter, setOwnerFilter] = useState<string>('all');
   const [methodFilter, setMethodFilter] = useState<string>('all');
-
-  // Sincronizar scheduledPayments del contexto al estado local
-  useEffect(() => {
-    setPayments(contextScheduledPayments);
-  }, [contextScheduledPayments]);
 
   // Calcular paymentDate automáticamente cuando se carga/selecciona una línea de servicio
   useEffect(() => {

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -14,6 +14,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/contexts/AuthContext';
+import { useData } from '@/contexts/DataContext';
 import { useServices } from '@/hooks/useServices';
 import { useBanks } from '@/hooks/useBanks';
 import { useServiceLines } from '@/hooks/useServiceLines';
@@ -117,14 +118,19 @@ const getNextDueDate = (billingDueDay: number): Date => {
 
 export function Payments() {
   const { currentUser } = useAuth();
+  const {
+    cards,
+    scheduledPayments: contextScheduledPayments,
+    paymentInstances,
+    loading,
+    refetchScheduledPayments,
+  } = useData();
   const { services } = useServices();
   const { banks } = useBanks();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [returnToDashboard, setReturnToDashboard] = useState(false);
   const [payments, setPayments] = useState<ScheduledPayment[]>([]);
-  const [cards, setCards] = useState<CardType[]>([]);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingPayment, setEditingPayment] = useState<ScheduledPayment | null>(null);
@@ -152,9 +158,6 @@ export function Payments() {
   // Hook para obtener todas las líneas de servicio (para mostrar sub-filas)
   const { serviceLines: allServiceLines } = useServiceLines({ activeOnly: false });
 
-  // Estado para instancias de pago (para calcular estado del ciclo vigente)
-  const [paymentInstances, setPaymentInstances] = useState<PaymentInstance[]>([]);
-
   const [amountInput, setAmountInput] = useState('');
   const [isEditingAmount, setIsEditingAmount] = useState(false);
   const [duplicatePayment, setDuplicatePayment] = useState<ScheduledPayment | null>(null);
@@ -175,6 +178,11 @@ export function Payments() {
   const [ownerFilter, setOwnerFilter] = useState<string>('all');
   const [methodFilter, setMethodFilter] = useState<string>('all');
 
+  // Sincronizar scheduledPayments del contexto al estado local
+  useEffect(() => {
+    setPayments(contextScheduledPayments);
+  }, [contextScheduledPayments]);
+
   // Calcular paymentDate automáticamente cuando se carga/selecciona una línea de servicio
   useEffect(() => {
     if (formData.frequency === 'billing_cycle' && formData.serviceLineId && selectedServiceLines.length > 0) {
@@ -187,12 +195,6 @@ export function Payments() {
       }
     }
   }, [formData.serviceLineId, selectedServiceLines, formData.frequency]);
-
-  useEffect(() => {
-    fetchPayments();
-    fetchCards();
-    fetchPaymentInstances();
-  }, [currentUser?.householdId]);
 
   // Calcular estado del ciclo vigente para cada línea de servicio
   const lineStatusMap = useMemo(() => {
@@ -281,77 +283,6 @@ export function Payments() {
       }
     }
   }, [searchParams, services, loading]);
-
-  const fetchCards = async () => {
-    if (!currentUser) return;
-
-    try {
-      const cardsQuery = query(
-        collection(db, 'cards'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(cardsQuery);
-      const cardsData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as CardType[];
-
-      setCards(cardsData.sort((a, b) => a.name.localeCompare(b.name)));
-    } catch (error) {
-      console.error('Error fetching cards:', error);
-    }
-  };
-
-  const fetchPayments = async () => {
-    if (!currentUser) return;
-
-    try {
-      const paymentsQuery = query(
-        collection(db, 'scheduled_payments'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(paymentsQuery);
-      const paymentsData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-        paymentDate: doc.data().paymentDate?.toDate(),
-      })) as ScheduledPayment[];
-
-      setPayments(paymentsData);
-    } catch (error) {
-      console.error('Error fetching payments:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchPaymentInstances = async () => {
-    if (!currentUser) return;
-
-    try {
-      const instancesQuery = query(
-        collection(db, 'payment_instances'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(instancesQuery);
-      const instancesData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        dueDate: doc.data().dueDate?.toDate() || new Date(),
-        paidDate: doc.data().paidDate?.toDate(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as PaymentInstance[];
-
-      setPaymentInstances(instancesData);
-    } catch (error) {
-      console.error('Error fetching payment instances:', error);
-    }
-  };
 
   // Obtener historial de pagos de un servicio
   const fetchServicePaymentHistory = async (serviceId: string, serviceLineId?: string) => {
@@ -569,7 +500,7 @@ export function Payments() {
         return;
       }
 
-      await fetchPayments();
+      await refetchScheduledPayments();
     } catch (error) {
       console.error('[Payments] Error saving payment:', error);
       toast.error('Error al guardar el pago');
@@ -606,7 +537,7 @@ export function Payments() {
     try {
       await deleteDoc(doc(db, 'scheduled_payments', paymentId));
       toast.success('Pago eliminado exitosamente');
-      await fetchPayments();
+      await refetchScheduledPayments();
     } catch (error) {
       console.error('Error deleting payment:', error);
       toast.error('Error al eliminar el pago');
@@ -620,7 +551,7 @@ export function Payments() {
         updatedAt: serverTimestamp(),
       });
       toast.success(payment.isActive ? 'Pago desactivado' : 'Pago activado');
-      await fetchPayments();
+      await refetchScheduledPayments();
     } catch (error) {
       console.error('Error toggling payment:', error);
       toast.error('Error al cambiar el estado del pago');

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,8 +1,5 @@
 import { useEffect, useState } from 'react';
-import { collection, query, where, getDocs } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
-import { useAuth } from '@/contexts/AuthContext';
-import type { Card as CardType, Service, ScheduledPayment, PaymentInstance } from '@/lib/types';
+import { useData } from '@/contexts/DataContext';
 import {
   calculateServicesAnalysis,
   calculateCashProjection,
@@ -18,14 +15,13 @@ import { DateRangeFilter } from '@/components/dashboard/DateRangeFilter';
 import type { DateRange } from '@/components/dashboard/DateRangeFilter';
 
 export function Reports() {
-  const { currentUser } = useAuth();
-  const [loading, setLoading] = useState(true);
-
-  // Data state
-  const [cards, setCards] = useState<CardType[]>([]);
-  const [services, setServices] = useState<Service[]>([]);
-  const [scheduledPayments, setScheduledPayments] = useState<ScheduledPayment[]>([]);
-  const [instances, setInstances] = useState<PaymentInstance[]>([]);
+  const {
+    cards,
+    services,
+    scheduledPayments,
+    paymentInstances: instances,
+    loading,
+  } = useData();
 
   // Date range state
   const [dateRange, setDateRange] = useState<DateRange>(() => {
@@ -41,86 +37,10 @@ export function Reports() {
   const [creditSummary, setCreditSummary] = useState<CreditSummary | null>(null);
 
   useEffect(() => {
-    fetchData();
-  }, [currentUser?.householdId]);
-
-  useEffect(() => {
     if (!loading) {
       calculateMetrics();
     }
-  }, [dateRange, loading]);
-
-  const fetchData = async () => {
-    if (!currentUser) return;
-
-    try {
-      setLoading(true);
-
-      // Fetch Cards
-      const cardsQuery = query(
-        collection(db, 'cards'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const cardsSnapshot = await getDocs(cardsQuery);
-      const cardsData = cardsSnapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as CardType[];
-      setCards(cardsData);
-
-      // Fetch Services
-      const servicesQuery = query(
-        collection(db, 'services'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const servicesSnapshot = await getDocs(servicesQuery);
-      const servicesData = servicesSnapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as Service[];
-      setServices(servicesData);
-
-      // Fetch Scheduled Payments
-      const scheduledQuery = query(
-        collection(db, 'scheduled_payments'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const scheduledSnapshot = await getDocs(scheduledQuery);
-      const scheduledData = scheduledSnapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        paymentDate: doc.data().paymentDate?.toDate(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as ScheduledPayment[];
-      setScheduledPayments(scheduledData);
-
-      // Fetch Payment Instances
-      const instancesQuery = query(
-        collection(db, 'payment_instances'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const instancesSnapshot = await getDocs(instancesQuery);
-      const instancesData = instancesSnapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        dueDate: doc.data().dueDate?.toDate() || new Date(),
-        paidDate: doc.data().paidDate?.toDate(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as PaymentInstance[];
-      setInstances(instancesData);
-
-    } catch (error) {
-      console.error('Error fetching data:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
+  }, [dateRange, loading, cards, services, scheduledPayments, instances]);
 
   const calculateMetrics = () => {
     // Use date range, or default to "all time" if null

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,5 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { useAuth } from '@/contexts/AuthContext';
 import { useData } from '@/contexts/DataContext';
+import type { PaymentInstance } from '@/lib/types';
 import {
   calculateServicesAnalysis,
   calculateCashProjection,
@@ -15,13 +19,17 @@ import { DateRangeFilter } from '@/components/dashboard/DateRangeFilter';
 import type { DateRange } from '@/components/dashboard/DateRangeFilter';
 
 export function Reports() {
+  const { currentUser } = useAuth();
   const {
     cards,
     services,
     scheduledPayments,
-    paymentInstances: instances,
+    paymentInstances: contextInstances,
     loading,
   } = useData();
+
+  // Instancias locales para rangos que exceden la ventana del contexto (3 meses)
+  const [localInstances, setLocalInstances] = useState<PaymentInstance[]>([]);
 
   // Date range state
   const [dateRange, setDateRange] = useState<DateRange>(() => {
@@ -30,6 +38,49 @@ export function Reports() {
     const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
     return { from: startOfMonth, to: endOfMonth, preset: 'current-month' };
   });
+
+  // Determinar si el rango de fecha excede la ventana del contexto (3 meses atras)
+  const needsExtendedFetch = useMemo(() => {
+    if (dateRange.preset === 'all' || dateRange.preset === 'last-6-months') return true;
+    if (!dateRange.from) return true;
+    const contextStart = new Date();
+    contextStart.setMonth(contextStart.getMonth() - 3, 1);
+    contextStart.setHours(0, 0, 0, 0);
+    return dateRange.from < contextStart;
+  }, [dateRange]);
+
+  // Fetch extendido cuando el rango excede la ventana del contexto
+  useEffect(() => {
+    if (!needsExtendedFetch || !currentUser) {
+      setLocalInstances([]);
+      return;
+    }
+    const fetchExtended = async () => {
+      try {
+        const q = query(
+          collection(db, 'payment_instances'),
+          where('householdId', '==', currentUser.householdId),
+        );
+        const snapshot = await getDocs(q);
+        setLocalInstances(snapshot.docs.map((doc) => {
+          const d = doc.data();
+          return {
+            ...d,
+            id: doc.id,
+            dueDate: d.dueDate?.toDate() || new Date(),
+            paidDate: d.paidDate?.toDate(),
+            createdAt: d.createdAt?.toDate() || new Date(),
+            updatedAt: d.updatedAt?.toDate() || new Date(),
+          } as PaymentInstance;
+        }));
+      } catch (err) {
+        console.error('Error fetching extended instances:', err);
+      }
+    };
+    fetchExtended();
+  }, [needsExtendedFetch, currentUser]);
+
+  const instances = needsExtendedFetch ? localInstances : contextInstances;
 
   // Metrics state
   const [servicesAnalysis, setServicesAnalysis] = useState<ServicesAnalysis | null>(null);

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -43,13 +43,12 @@ import {
 export function Services() {
   const { currentUser } = useAuth();
   const {
-    services: contextServices,
+    services,
     paymentInstances,
     loading,
     refetchServices,
   } = useData();
   const [searchParams] = useSearchParams();
-  const [services, setServices] = useState<Service[]>([]);
   const [saving, setSaving] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
@@ -69,11 +68,6 @@ export function Services() {
 
   // Hook para obtener líneas de servicio agrupadas
   const { linesCountByService, refetch: refetchServiceLines } = useServiceLinesGrouped();
-
-  // Sincronizar services del contexto al estado local
-  useEffect(() => {
-    setServices(contextServices);
-  }, [contextServices]);
 
   // Abrir panel de servicio automáticamente si viene viewService en la URL (desde alertas del Dashboard)
   useEffect(() => {

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,18 +1,16 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
-  collection,
-  query,
-  where,
-  getDocs,
   addDoc,
   updateDoc,
   deleteDoc,
   doc,
+  collection,
   serverTimestamp,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/contexts/AuthContext';
+import { useData } from '@/contexts/DataContext';
 import { toast } from 'sonner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -25,7 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { Service, ServiceFormData, PaymentMethod, ServiceType, PaymentInstance } from '@/lib/types';
+import type { Service, ServiceFormData, PaymentMethod, ServiceType } from '@/lib/types';
 import { Store, Plus, X, Search, Loader2, CreditCard, Banknote, Edit, Calendar, CalendarCheck, Cable } from 'lucide-react';
 import { ViewToggle, type ViewMode } from '@/components/ui/view-toggle';
 import { ServiceGridItem } from '@/components/services/ServiceGridItem';
@@ -44,10 +42,14 @@ import {
 
 export function Services() {
   const { currentUser } = useAuth();
+  const {
+    services: contextServices,
+    paymentInstances,
+    loading,
+    refetchServices,
+  } = useData();
   const [searchParams] = useSearchParams();
   const [services, setServices] = useState<Service[]>([]);
-  const [paymentInstances, setPaymentInstances] = useState<PaymentInstance[]>([]);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
@@ -68,10 +70,10 @@ export function Services() {
   // Hook para obtener líneas de servicio agrupadas
   const { linesCountByService, refetch: refetchServiceLines } = useServiceLinesGrouped();
 
+  // Sincronizar services del contexto al estado local
   useEffect(() => {
-    fetchServices();
-    fetchPaymentInstances();
-  }, [currentUser?.householdId]);
+    setServices(contextServices);
+  }, [contextServices]);
 
   // Abrir panel de servicio automáticamente si viene viewService en la URL (desde alertas del Dashboard)
   useEffect(() => {
@@ -84,55 +86,19 @@ export function Services() {
     }
   }, [searchParams, services, loading]);
 
-  const fetchServices = async (): Promise<Service[]> => {
-    if (!currentUser) return [];
+  // Estado para reabrir el sheet del servicio después de editar
+  const [pendingReopenServiceId, setPendingReopenServiceId] = useState<string | null>(null);
 
-    try {
-      const servicesQuery = query(
-        collection(db, 'services'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(servicesQuery);
-      const servicesData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as Service[];
-
-      setServices(servicesData);
-      return servicesData;
-    } catch (error) {
-      console.error('Error fetching services:', error);
-      return [];
-    } finally {
-      setLoading(false);
+  // Cuando services se actualizan y hay un pendingReopenServiceId, reabrir el sheet
+  useEffect(() => {
+    if (pendingReopenServiceId && services.length > 0) {
+      const updatedService = services.find(s => s.id === pendingReopenServiceId);
+      if (updatedService) {
+        setViewingService(updatedService);
+      }
+      setPendingReopenServiceId(null);
     }
-  };
-
-  const fetchPaymentInstances = async () => {
-    if (!currentUser) return;
-
-    try {
-      const instancesQuery = query(
-        collection(db, 'payment_instances'),
-        where('householdId', '==', currentUser.householdId)
-      );
-      const snapshot = await getDocs(instancesQuery);
-      const instancesData = snapshot.docs.map((doc) => ({
-        ...doc.data(),
-        id: doc.id,
-        dueDate: doc.data().dueDate?.toDate() || new Date(),
-        paidDate: doc.data().paidDate?.toDate(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      })) as PaymentInstance[];
-
-      setPaymentInstances(instancesData);
-    } catch (error) {
-      console.error('Error fetching payment instances:', error);
-    }
-  };
+  }, [services, pendingReopenServiceId]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -193,14 +159,11 @@ export function Services() {
 
       const serviceIdToReopen = editingFromView;
       resetForm();
-      const updatedServices = await fetchServices();
+      await refetchServices();
 
-      // Si estábamos editando desde el Sheet, reabrir con el servicio actualizado
+      // Si estábamos editando desde el Sheet, reabrir cuando services se actualicen
       if (serviceIdToReopen) {
-        const updatedService = updatedServices.find(s => s.id === serviceIdToReopen);
-        if (updatedService) {
-          setViewingService(updatedService);
-        }
+        setPendingReopenServiceId(serviceIdToReopen);
       }
     } catch (error) {
       console.error('Error saving service:', error);
@@ -240,7 +203,7 @@ export function Services() {
     try {
       await deleteDoc(doc(db, 'services', serviceId));
       toast.success('Servicio eliminado exitosamente');
-      await fetchServices();
+      await refetchServices();
     } catch (error) {
       console.error('Error deleting service:', error);
       toast.error('Error al eliminar el servicio');


### PR DESCRIPTION
## Summary
- Crear DataContext que centraliza fetch de 6 colecciones en paralelo (1 vez al montar)
- Habilitar `persistentLocalCache` en Firestore para cache entre sesiones
- Migrar 7 paginas y 3 hooks para compartir datos del contexto en vez de queries independientes
- Reduccion estimada: ~972 → ~210 autorizaciones de reglas por sesion (~78%)

## Cambios clave
- `src/lib/firebase.ts` — `initializeFirestore` con `persistentLocalCache`
- `src/contexts/DataContext.tsx` — Nuevo contexto con fetch paralelo, helper DRY, errors tipados
- `src/hooks/useBanks|useServices|useServiceLines.ts` — Wrappers del contexto con sort/filter en memoria
- `src/pages/*` — Eliminadas queries directas; usan `useData()` del contexto
- Reports y PaymentCalendar mantienen fetch independiente cuando el rango excede la ventana de 3 meses
- Queries on-demand (fetchCardPayments, fetchServicePaymentHistory) se mantienen sin cambio

## Test plan
- [ ] `npm run build` pasa sin errores TypeScript
- [ ] Navegar Dashboard → Cards → Payments → Calendar sin errores
- [ ] Verificar en Firebase Console que autorizaciones son ~200-250 (no ~970)
- [ ] Crear/editar tarjetas, pagos y servicios actualiza datos correctamente
- [ ] Calendar con filtro "Todos" sigue mostrando historico completo
- [ ] Reports con preset "Ultimos 6 meses" y "Todos los datos" muestra datos completos

🤖 Generated with [Claude Code](https://claude.com/claude-code)