### PR TITLE
Fix: Reducir lecturas excesivas de Firestore (~1.1K reads/min)

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -167,6 +167,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         collection(db, 'payment_instances'),
         where('householdId', '==', householdId),
         where('dueDate', '>=', Timestamp.fromDate(startDate)),
+        where('dueDate', '<=', Timestamp.fromDate(endDate)),
         orderBy('dueDate', 'asc'),
       );
       const snapshot = await getDocs(q);
@@ -182,8 +183,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         } as PaymentInstance;
       });
 
-      // Filtrar rango superior en cliente
-      setPaymentInstances(data.filter(instance => instance.dueDate <= endDate));
+      setPaymentInstances(data);
       setErrors(prev => prev.paymentInstances === null ? prev : { ...prev, paymentInstances: null });
     } catch (err) {
       console.error('Error fetching payment instances:', err);

--- a/src/lib/paymentInstances.ts
+++ b/src/lib/paymentInstances.ts
@@ -2,12 +2,14 @@ import {
   collection,
   query,
   where,
+  orderBy,
   getDocs,
   addDoc,
   updateDoc,
   doc,
   serverTimestamp,
   Timestamp,
+  type QueryConstraint,
 } from 'firebase/firestore';
 import { db } from './firebase';
 import type {
@@ -477,10 +479,12 @@ export async function generateCurrentAndNextMonthInstances(
     allInstances = [...currentMonthInstances, ...nextMonthInstances];
   }
 
-  // Siempre revalidar contra Firestore para evitar duplicados en households compartidos
+  // Revalidar contra Firestore para evitar duplicados, acotado al rango mes actual → fin mes siguiente
   const existingInstances = await getExistingInstances(
     scheduledPayment.householdId,
-    scheduledPayment.id
+    scheduledPayment.id,
+    currentMonth.start,
+    nextMonth.end
   );
 
   // Filtrar las que no existen
@@ -517,13 +521,24 @@ export async function generateCurrentAndNextMonthInstances(
  */
 async function getExistingInstances(
   householdId: string,
-  scheduledPaymentId: string
+  scheduledPaymentId: string,
+  startDate?: Date,
+  endDate?: Date
 ): Promise<PaymentInstance[]> {
-  const q = query(
-    collection(db, 'payment_instances'),
+  const constraints: QueryConstraint[] = [
     where('householdId', '==', householdId),
-    where('scheduledPaymentId', '==', scheduledPaymentId)
-  );
+    where('scheduledPaymentId', '==', scheduledPaymentId),
+  ];
+
+  if (startDate && endDate) {
+    constraints.push(
+      where('dueDate', '>=', Timestamp.fromDate(startDate)),
+      where('dueDate', '<=', Timestamp.fromDate(endDate)),
+      orderBy('dueDate', 'asc')
+    );
+  }
+
+  const q = query(collection(db, 'payment_instances'), ...constraints);
 
   const snapshot = await getDocs(q);
   return snapshot.docs.map((doc) => ({

--- a/src/pages/PaymentCalendar.tsx
+++ b/src/pages/PaymentCalendar.tsx
@@ -4,10 +4,10 @@ import {
   collection,
   query,
   where,
+  orderBy,
   getDocs,
   updateDoc,
   doc,
-  getDoc,
   serverTimestamp,
   Timestamp,
   arrayUnion,
@@ -196,17 +196,15 @@ export function PaymentCalendar() {
     if (!currentUser) return;
 
     try {
-      const cardRef = doc(db, 'cards', cardId);
-      const cardDoc = await getDoc(cardRef);
-
-      if (!cardDoc.exists()) {
+      // Usar datos del contexto en vez de getDoc
+      const card = cards.find(c => c.id === cardId);
+      if (!card) {
         console.error('Card not found:', cardId);
         return;
       }
 
-      const cardData = cardDoc.data();
-      const currentAvailable = cardData.availableCredit || 0;
-      const creditLimit = cardData.creditLimit || 0;
+      const currentAvailable = card.availableCredit || 0;
+      const creditLimit = card.creditLimit || 0;
 
       // Calcular nuevo disponible
       const newAvailableCredit = operation === 'add'
@@ -217,6 +215,7 @@ export function PaymentCalendar() {
       const newCurrentBalance = creditLimit - newAvailableCredit;
 
       // Actualizar en Firestore
+      const cardRef = doc(db, 'cards', cardId);
       await updateDoc(cardRef, {
         availableCredit: newAvailableCredit,
         currentBalance: newCurrentBalance,
@@ -273,11 +272,13 @@ export function PaymentCalendar() {
       const instancesQuery = query(
         collection(db, 'payment_instances'),
         where('householdId', '==', currentUser.householdId),
-        where('dueDate', '>=', Timestamp.fromDate(queryStartDate))
+        where('dueDate', '>=', Timestamp.fromDate(queryStartDate)),
+        where('dueDate', '<=', Timestamp.fromDate(queryEndDate)),
+        orderBy('dueDate', 'asc')
       );
 
       const snapshot = await getDocs(instancesQuery);
-      let instancesData = snapshot.docs.map((doc) => ({
+      const instancesData = snapshot.docs.map((doc) => ({
         ...doc.data(),
         id: doc.id,
         dueDate: doc.data().dueDate?.toDate() || new Date(),
@@ -285,14 +286,6 @@ export function PaymentCalendar() {
         createdAt: doc.data().createdAt?.toDate() || new Date(),
         updatedAt: doc.data().updatedAt?.toDate() || new Date(),
       })) as PaymentInstance[];
-
-      // Filtrar por rango superior en el cliente
-      instancesData = instancesData.filter(
-        (instance) => instance.dueDate <= queryEndDate
-      );
-
-      // Ordenar por fecha
-      instancesData.sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
 
       setLocalInstances(instancesData);
     } catch (error) {

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { collection, query, where, getDocs } from 'firebase/firestore';
+import { collection, query, where, orderBy, getDocs, Timestamp, type QueryConstraint } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/contexts/AuthContext';
 import { useData } from '@/contexts/DataContext';
@@ -57,9 +57,36 @@ export function Reports() {
     }
     const fetchExtended = async () => {
       try {
+        // Acotar query con filtro de fecha según el preset
+        const constraints: QueryConstraint[] = [
+          where('householdId', '==', currentUser.householdId),
+        ];
+
+        if (dateRange.preset === 'last-6-months') {
+          const sixMonthsAgo = new Date();
+          sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6, 1);
+          sixMonthsAgo.setHours(0, 0, 0, 0);
+          constraints.push(
+            where('dueDate', '>=', Timestamp.fromDate(sixMonthsAgo)),
+            orderBy('dueDate', 'asc')
+          );
+        } else if (dateRange.from) {
+          // Para 'all' u otros rangos custom con fecha de inicio
+          constraints.push(
+            where('dueDate', '>=', Timestamp.fromDate(dateRange.from)),
+            orderBy('dueDate', 'asc')
+          );
+        }
+
+        if (dateRange.to) {
+          constraints.push(
+            where('dueDate', '<=', Timestamp.fromDate(dateRange.to))
+          );
+        }
+
         const q = query(
           collection(db, 'payment_instances'),
-          where('householdId', '==', currentUser.householdId),
+          ...constraints,
         );
         const snapshot = await getDocs(q);
         setLocalInstances(snapshot.docs.map((doc) => {
@@ -78,7 +105,7 @@ export function Reports() {
       }
     };
     fetchExtended();
-  }, [needsExtendedFetch, currentUser]);
+  }, [needsExtendedFetch, currentUser?.householdId, dateRange]);
 
   const instances = needsExtendedFetch ? localInstances : contextInstances;
 


### PR DESCRIPTION
## Summary
- Agrega upper-bound (`where dueDate <= endDate`) a 3 queries que solo tenían lower-bound, causando lectura de documentos futuros descartados en cliente
- Acota `getExistingInstances` con rango de fecha (mes actual → fin mes siguiente) en vez de leer todo el histórico por scheduled_payment
- Elimina `getDoc` redundante en `updateCardAvailableCredit` usando datos del contexto
- Agrega filtro de fecha en Reports para `last-6-months` y corrige dep-array de `currentUser` → `currentUser?.householdId`

## Test plan
- [ ] Abrir Dashboard → verificar que instancias se cargan correctamente
- [ ] Navegar al Calendario → cambiar filtro a "Todos" → verificar datos correctos
- [ ] Marcar un pago como pagado → verificar que crédito disponible se actualiza
- [ ] Ir a Reports → seleccionar "Últimos 6 meses" → verificar métricas
- [ ] Monitorear Firebase Console > Usage → confirmar reducción significativa de reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)