### PR TITLE
Perf: Eliminar lecturas duplicadas de payment_instances

### DIFF
--- a/src/components/services/ServiceLineList.tsx
+++ b/src/components/services/ServiceLineList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import {
   collection,
   addDoc,
@@ -6,13 +6,10 @@ import {
   deleteDoc,
   doc,
   serverTimestamp,
-  query,
-  where,
-  getDocs,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/contexts/AuthContext';
-import type { ScheduledPayment } from '@/lib/types';
+import { useData } from '@/contexts/DataContext';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -47,6 +44,7 @@ interface ServiceLineListProps {
 
 export function ServiceLineList({ service, onLinesChange }: ServiceLineListProps) {
   const { currentUser } = useAuth();
+  const { scheduledPayments: allScheduledPayments } = useData();
   const { serviceLines, loading, refetch } = useServiceLines({
     serviceId: service.id,
     activeOnly: false, // Mostrar todas, activas e inactivas
@@ -54,33 +52,12 @@ export function ServiceLineList({ service, onLinesChange }: ServiceLineListProps
 
   const [showForm, setShowForm] = useState(false);
   const [editingLine, setEditingLine] = useState<ServiceLine | null>(null);
-  const [scheduledPayments, setScheduledPayments] = useState<ScheduledPayment[]>([]);
 
-  // Cargar pagos programados del servicio
-  useEffect(() => {
-    const fetchScheduledPayments = async () => {
-      if (!currentUser || !service.id) return;
-
-      try {
-        const paymentsQuery = query(
-          collection(db, 'scheduled_payments'),
-          where('householdId', '==', currentUser.householdId),
-          where('serviceId', '==', service.id),
-          where('isActive', '==', true)
-        );
-        const snapshot = await getDocs(paymentsQuery);
-        const payments = snapshot.docs.map((doc) => ({
-          ...doc.data(),
-          id: doc.id,
-        })) as ScheduledPayment[];
-        setScheduledPayments(payments);
-      } catch (error) {
-        console.error('Error fetching scheduled payments:', error);
-      }
-    };
-
-    fetchScheduledPayments();
-  }, [currentUser?.householdId, service.id]);
+  // Filtrar pagos programados del servicio en memoria
+  const scheduledPayments = useMemo(
+    () => allScheduledPayments.filter(sp => sp.serviceId === service.id && sp.isActive),
+    [allScheduledPayments, service.id]
+  );
 
   // Verificar si una línea tiene pago programado
   const hasScheduledPayment = (lineId: string): boolean => {

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -39,6 +39,7 @@ interface DataContextType {
   refetchScheduledPayments: () => Promise<void>;
   refetchPaymentInstances: () => Promise<void>;
   refetchAll: () => Promise<void>;
+  appendPaymentInstances: (newInstances: PaymentInstance[]) => void;
 }
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
@@ -191,6 +192,15 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     }
   }, [householdId]);
 
+  const appendPaymentInstances = useCallback((newInstances: PaymentInstance[]) => {
+    setPaymentInstances(prev => {
+      const existingIds = new Set(prev.map(i => i.id));
+      const unique = newInstances.filter(i => !existingIds.has(i.id));
+      if (unique.length === 0) return prev;
+      return [...prev, ...unique].sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+    });
+  }, []);
+
   const refetchAll = useCallback(async () => {
     if (!householdId) return;
     await Promise.allSettled([
@@ -223,10 +233,11 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     refetchScheduledPayments: fetchScheduledPayments,
     refetchPaymentInstances: fetchPaymentInstances,
     refetchAll,
+    appendPaymentInstances,
   }), [
     cards, banks, services, serviceLines, scheduledPayments, paymentInstances,
     loading, errors,
-    fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances, refetchAll,
+    fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances, refetchAll, appendPaymentInstances,
   ]);
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>;

--- a/src/lib/paymentInstances.ts
+++ b/src/lib/paymentInstances.ts
@@ -497,30 +497,33 @@ export async function generateCurrentAndNextMonthInstances(
       )
   );
 
-  // Guardar en Firestore y retornar instancias creadas con ID
-  const created: PaymentInstance[] = [];
-  for (const instance of instancesToCreate) {
-    try {
-      const dataToSave = {
-        ...instance,
-        dueDate: Timestamp.fromDate(instance.dueDate),
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-      };
+  // Guardar en Firestore en paralelo y retornar instancias creadas con ID
+  // Nota: createdAt/updatedAt usan Date del cliente (aproximado) ya que serverTimestamp()
+  // no se resuelve hasta que Firestore lo procesa. Valores exactos se obtienen en el próximo refetch.
+  const created = await Promise.all(
+    instancesToCreate.map(async (instance) => {
+      try {
+        const dataToSave = {
+          ...instance,
+          dueDate: Timestamp.fromDate(instance.dueDate),
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        };
 
-      const docRef = await addDoc(collection(db, 'payment_instances'), dataToSave);
-      created.push({
-        ...instance,
-        id: docRef.id,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-    } catch (error) {
-      console.error('[PaymentInstances] ❌ Error guardando instancia:', error);
-      console.error('[PaymentInstances] Datos que causaron el error:', instance);
-      throw error;
-    }
-  }
+        const docRef = await addDoc(collection(db, 'payment_instances'), dataToSave);
+        return {
+          ...instance,
+          id: docRef.id,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+      } catch (error) {
+        console.error('[PaymentInstances] ❌ Error guardando instancia:', error);
+        console.error('[PaymentInstances] Datos que causaron el error:', instance);
+        throw error;
+      }
+    })
+  );
   return created;
 }
 

--- a/src/lib/paymentInstances.ts
+++ b/src/lib/paymentInstances.ts
@@ -429,8 +429,8 @@ export async function generateCurrentAndNextMonthInstances(
   scheduledPayment: ScheduledPayment,
   service?: Service,
   serviceLine?: ServiceLine
-): Promise<void> {
-  if (!scheduledPayment.isActive) return;
+): Promise<PaymentInstance[]> {
+  if (!scheduledPayment.isActive) return [];
 
   const currentMonth = getCurrentMonthRange();
   const nextMonth = getNextMonthRange();
@@ -497,7 +497,8 @@ export async function generateCurrentAndNextMonthInstances(
       )
   );
 
-  // Guardar en Firestore
+  // Guardar en Firestore y retornar instancias creadas con ID
+  const created: PaymentInstance[] = [];
   for (const instance of instancesToCreate) {
     try {
       const dataToSave = {
@@ -507,13 +508,20 @@ export async function generateCurrentAndNextMonthInstances(
         updatedAt: serverTimestamp(),
       };
 
-      await addDoc(collection(db, 'payment_instances'), dataToSave);
+      const docRef = await addDoc(collection(db, 'payment_instances'), dataToSave);
+      created.push({
+        ...instance,
+        id: docRef.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
     } catch (error) {
       console.error('[PaymentInstances] ❌ Error guardando instancia:', error);
       console.error('[PaymentInstances] Datos que causaron el error:', instance);
       throw error;
     }
   }
+  return created;
 }
 
 /**
@@ -565,9 +573,10 @@ export async function ensureMonthlyInstances(
   services?: Service[],
   serviceLines?: ServiceLine[],
   existingInstances?: PaymentInstance[]
-): Promise<void> {
+): Promise<PaymentInstance[]> {
   const currentMonth = getCurrentMonthRange();
   const nextMonth = getNextMonthRange();
+  const allCreated: PaymentInstance[] = [];
 
   for (const scheduledPayment of scheduledPayments) {
     if (!scheduledPayment.isActive) continue;
@@ -631,9 +640,12 @@ export async function ensureMonthlyInstances(
         ? serviceLines?.find(sl => sl.id === scheduledPayment.serviceLineId)
         : undefined;
 
-      await generateCurrentAndNextMonthInstances(scheduledPayment, service, serviceLine);
+      const created = await generateCurrentAndNextMonthInstances(scheduledPayment, service, serviceLine);
+      allCreated.push(...created);
     }
   }
+
+  return allCreated;
 }
 
 /**

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -10,7 +10,6 @@ import {
   doc,
   serverTimestamp,
   arrayUnion,
-  getDoc,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useData } from '@/contexts/DataContext';
@@ -165,17 +164,14 @@ export function Cards() {
     if (!currentUser) return;
 
     try {
-      const cardRef = doc(db, 'cards', cardId);
-      const cardDoc = await getDoc(cardRef);
-
-      if (!cardDoc.exists()) {
+      const card = cards.find(c => c.id === cardId);
+      if (!card) {
         console.error('Card not found:', cardId);
         return;
       }
 
-      const cardData = cardDoc.data();
-      const currentAvailable = cardData.availableCredit || 0;
-      const creditLimit = cardData.creditLimit || 0;
+      const currentAvailable = card.availableCredit || 0;
+      const creditLimit = card.creditLimit || 0;
 
       // Calcular nuevo disponible
       const newAvailableCredit = operation === 'add'
@@ -186,7 +182,7 @@ export function Cards() {
       const newCurrentBalance = creditLimit - newAvailableCredit;
 
       // Actualizar en Firestore
-      await updateDoc(cardRef, {
+      await updateDoc(doc(db, 'cards', cardId), {
         availableCredit: newAvailableCredit,
         currentBalance: newCurrentBalance,
         updatedAt: serverTimestamp(),

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -10,6 +10,7 @@ import {
   doc,
   serverTimestamp,
   arrayUnion,
+  getDoc,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useData } from '@/contexts/DataContext';
@@ -164,14 +165,19 @@ export function Cards() {
     if (!currentUser) return;
 
     try {
-      const card = cards.find(c => c.id === cardId);
-      if (!card) {
+      // Leer el documento más reciente de Firestore para evitar lost updates
+      // (otro usuario del hogar pudo haber modificado el saldo)
+      const cardRef = doc(db, 'cards', cardId);
+      const cardDoc = await getDoc(cardRef);
+
+      if (!cardDoc.exists()) {
         console.error('Card not found:', cardId);
         return;
       }
 
-      const currentAvailable = card.availableCredit || 0;
-      const creditLimit = card.creditLimit || 0;
+      const cardData = cardDoc.data();
+      const currentAvailable = cardData.availableCredit || 0;
+      const creditLimit = cardData.creditLimit || 0;
 
       // Calcular nuevo disponible
       const newAvailableCredit = operation === 'add'
@@ -182,7 +188,7 @@ export function Cards() {
       const newCurrentBalance = creditLimit - newAvailableCredit;
 
       // Actualizar en Firestore
-      await updateDoc(doc(db, 'cards', cardId), {
+      await updateDoc(cardRef, {
         availableCredit: newAvailableCredit,
         currentBalance: newCurrentBalance,
         updatedAt: serverTimestamp(),

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -28,7 +28,7 @@ export function Dashboard() {
     paymentInstances,
     scheduledPayments,
     loading,
-    refetchPaymentInstances,
+    appendPaymentInstances,
   } = useData();
   const { services } = useServices();
   const { banks } = useBanks();
@@ -52,7 +52,7 @@ export function Dashboard() {
     const generateMissingInstances = async () => {
       isGeneratingRef.current = true;
       try {
-        await ensureMonthlyInstances(
+        const newInstances = await ensureMonthlyInstances(
           householdId,
           scheduledPayments,
           servicesRef.current,
@@ -60,8 +60,9 @@ export function Dashboard() {
           paymentInstancesRef.current
         );
         instancesGeneratedRef.current = true;
-        // Refetch para obtener instancias recién creadas
-        await refetchPaymentInstances();
+        if (newInstances.length > 0) {
+          appendPaymentInstances(newInstances);
+        }
       } catch (error: unknown) {
         const firebaseError = error as { message?: string; code?: string };
         console.error('[Dashboard] Error generando instancias:', firebaseError.code, firebaseError.message);
@@ -71,7 +72,7 @@ export function Dashboard() {
     };
 
     generateMissingInstances();
-  }, [householdId, loading, scheduledPayments, refetchPaymentInstances]);
+  }, [householdId, loading, scheduledPayments, appendPaymentInstances]);
 
   // Rango de fechas fijo: mes actual
   const dateRange = useMemo(() => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -43,25 +43,29 @@ export function Dashboard() {
   serviceLinesRef.current = serviceLines;
   const paymentInstancesRef = useRef(paymentInstances);
   paymentInstancesRef.current = paymentInstances;
+  const scheduledPaymentsRef = useRef(scheduledPayments);
+  scheduledPaymentsRef.current = scheduledPayments;
+  const appendPaymentInstancesRef = useRef(appendPaymentInstances);
+  appendPaymentInstancesRef.current = appendPaymentInstances;
 
   // Trigger: generar instancias faltantes del mes actual y siguiente
   useEffect(() => {
     if (!householdId || loading || instancesGeneratedRef.current || isGeneratingRef.current) return;
-    if (scheduledPayments.length === 0) return;
+    if (scheduledPaymentsRef.current.length === 0) return;
 
     const generateMissingInstances = async () => {
       isGeneratingRef.current = true;
       try {
         const newInstances = await ensureMonthlyInstances(
           householdId,
-          scheduledPayments,
+          scheduledPaymentsRef.current,
           servicesRef.current,
           serviceLinesRef.current,
           paymentInstancesRef.current
         );
         instancesGeneratedRef.current = true;
         if (newInstances.length > 0) {
-          appendPaymentInstances(newInstances);
+          appendPaymentInstancesRef.current(newInstances);
         }
       } catch (error: unknown) {
         const firebaseError = error as { message?: string; code?: string };
@@ -72,7 +76,7 @@ export function Dashboard() {
     };
 
     generateMissingInstances();
-  }, [householdId, loading, scheduledPayments, appendPaymentInstances]);
+  }, [householdId, loading]);
 
   // Rango de fechas fijo: mes actual
   const dateRange = useMemo(() => {


### PR DESCRIPTION
## Summary
- `ensureMonthlyInstances` y `generateCurrentAndNextMonthInstances` ahora retornan las instancias creadas, permitiendo agregarlas al estado local sin re-leer Firestore
- Nuevo `appendPaymentInstances` en DataContext agrega instancias en memoria (dedup + sort)
- Dashboard usa `appendPaymentInstances` en vez de `refetchPaymentInstances`, eliminando la segunda lectura de ~200+ docs
- ServiceLineList usa `useData().scheduledPayments` filtrado con `useMemo` en vez de `getDocs` propio
- `addDoc` secuencial → `Promise.all` para reducir latencia de red
- Deps del efecto de generación estabilizados con refs (`[householdId, loading]`)

## Test plan
- [ ] Abrir Dashboard → verificar que instancias se generan y aparecen sin delay
- [ ] Verificar en console que NO aparece log de `fetchPaymentInstances` después de la generación
- [ ] Navegar a Services → verificar que líneas muestran badge "Pago programado" correctamente
- [ ] Monitorear pico de lecturas en Firebase Console: objetivo < 500/minuto por carga

🤖 Generated with [Claude Code](https://claude.com/claude-code)