### PR TITLE
Perf: evitar refetch masivo de payment_instances tras mutaciones

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -40,6 +40,7 @@ interface DataContextType {
   refetchPaymentInstances: () => Promise<void>;
   refetchAll: () => Promise<void>;
   appendPaymentInstances: (newInstances: PaymentInstance[]) => void;
+  upsertPaymentInstance: (instance: PaymentInstance) => void;
 }
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
@@ -201,6 +202,18 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const upsertPaymentInstance = useCallback((instance: PaymentInstance) => {
+    setPaymentInstances(prev => {
+      const index = prev.findIndex(i => i.id === instance.id);
+      if (index === -1) {
+        return [...prev, instance].sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+      }
+      const next = [...prev];
+      next[index] = instance;
+      return next.sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+    });
+  }, []);
+
   const refetchAll = useCallback(async () => {
     if (!householdId) return;
     await Promise.allSettled([
@@ -234,10 +247,11 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     refetchPaymentInstances: fetchPaymentInstances,
     refetchAll,
     appendPaymentInstances,
+    upsertPaymentInstance,
   }), [
     cards, banks, services, serviceLines, scheduledPayments, paymentInstances,
     loading, errors,
-    fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances, refetchAll, appendPaymentInstances,
+    fetchCards, fetchBanks, fetchServices, fetchServiceLines, fetchScheduledPayments, fetchPaymentInstances, refetchAll, appendPaymentInstances, upsertPaymentInstance,
   ]);
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>;

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -247,6 +247,21 @@ export function Cards() {
     }
   };
 
+  const upsertCardPayment = (instance: PaymentInstance) => {
+    setCardPayments(prev => {
+      const index = prev.findIndex(p => p.id === instance.id);
+      if (index === -1) {
+        return [...prev, instance].sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+      }
+      const next = [...prev];
+      next[index] = instance;
+      return next.sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+    });
+    if (editingPayment?.id === instance.id) {
+      setEditingPayment(instance);
+    }
+  };
+
   const handleMarkAsPaid = async (instance: PaymentInstance) => {
     if (!currentUser) return;
 
@@ -269,12 +284,16 @@ export function Cards() {
         await updateCardAvailableCredit(instance.cardId, amountBeingPaid, 'add');
       }
 
-      toast.success('Pago marcado como realizado');
+      upsertCardPayment({
+        ...instance,
+        status: 'paid',
+        paidDate: new Date(),
+        paidAmount: instance.amount,
+        remainingAmount: 0,
+        updatedAt: new Date(),
+      });
 
-      // Recargar pagos de la tarjeta
-      if (viewingCard) {
-        await fetchCardPayments(viewingCard.id);
-      }
+      toast.success('Pago marcado como realizado');
     } catch (error) {
       console.error('Error marking as paid:', error);
       toast.error('Error al marcar como pagado');
@@ -343,6 +362,16 @@ export function Cards() {
         await updateCardAvailableCredit(editingPayment.cardId, amountToPay, 'add');
       }
 
+      upsertCardPayment({
+        ...editingPayment,
+        status: isFullyPaid ? 'paid' : 'partial',
+        paidAmount: newPaidAmount,
+        remainingAmount: newRemainingAmount,
+        partialPayments: [...(editingPayment.partialPayments || []), newPartialPayment],
+        paidDate: isFullyPaid ? new Date() : editingPayment.paidDate,
+        updatedAt: new Date(),
+      });
+
       toast.success(
         isFullyPaid
           ? 'Pago completado'
@@ -353,11 +382,6 @@ export function Cards() {
       setEditingPayment(null);
       setPartialAmount('');
       setPartialNotes('');
-
-      // Recargar pagos de la tarjeta
-      if (viewingCard) {
-        await fetchCardPayments(viewingCard.id);
-      }
     } catch (error) {
       console.error('Error saving partial payment:', error);
       toast.error('Error al registrar el pago parcial');
@@ -411,12 +435,17 @@ export function Cards() {
         await updateCardAvailableCredit(instance.cardId, payment.amount, 'subtract');
       }
 
-      toast.success('Pago parcial eliminado');
+      upsertCardPayment({
+        ...instance,
+        status: newPaidAmount === 0 ? 'pending' : 'partial',
+        paidAmount: newPaidAmount === 0 ? undefined : newPaidAmount,
+        remainingAmount: newRemainingAmount,
+        partialPayments: updatedPartialPayments,
+        paidDate: newPaidAmount === 0 ? undefined : instance.paidDate,
+        updatedAt: new Date(),
+      });
 
-      // Recargar pagos de la tarjeta
-      if (viewingCard) {
-        await fetchCardPayments(viewingCard.id);
-      }
+      toast.success('Pago parcial eliminado');
     } catch (error: any) {
       console.error('Error deleting partial payment:', error);
       toast.error('Error al eliminar el pago parcial');

--- a/src/pages/PaymentCalendar.tsx
+++ b/src/pages/PaymentCalendar.tsx
@@ -97,8 +97,8 @@ export function PaymentCalendar() {
     scheduledPayments,
     paymentInstances: contextInstances,
     loading: dataLoading,
-    refetchPaymentInstances,
     refetchCards,
+    upsertPaymentInstance,
   } = useData();
   const { services } = useServices();
   const { banks } = useBanks();
@@ -231,15 +231,6 @@ export function PaymentCalendar() {
     }
   };
 
-  // Después de mutaciones, refrescar instancias según el filtro activo
-  const refreshInstances = async () => {
-    if (timeFilter === 'all' || (timeFilter === 'custom' && customStartDate)) {
-      await fetchInstances();
-    } else {
-      await refetchPaymentInstances();
-    }
-  };
-
   const fetchInstances = async () => {
     if (!currentUser) return;
     setLocalLoading(true);
@@ -292,6 +283,39 @@ export function PaymentCalendar() {
       console.error('Error fetching instances:', error);
     } finally {
       setLocalLoading(false);
+    }
+  };
+
+  const mergePaymentInstance = (
+    instance: PaymentInstance,
+    patch: Partial<PaymentInstance>
+  ): PaymentInstance => ({
+    ...instance,
+    ...patch,
+    updatedAt: new Date(),
+  });
+
+  const upsertLocalInstance = (instance: PaymentInstance) => {
+    setLocalInstances(prev => {
+      const index = prev.findIndex(i => i.id === instance.id);
+      if (index === -1) {
+        return [...prev, instance].sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+      }
+      const next = [...prev];
+      next[index] = instance;
+      return next.sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+    });
+  };
+
+  const syncUpdatedInstance = (instance: PaymentInstance, patch: Partial<PaymentInstance>) => {
+    const updatedInstance = mergePaymentInstance(instance, patch);
+    if (needsLocalFetch) {
+      upsertLocalInstance(updatedInstance);
+    } else {
+      upsertPaymentInstance(updatedInstance);
+    }
+    if (editingInstance?.id === updatedInstance.id) {
+      setEditingInstance(updatedInstance);
     }
   };
 
@@ -545,8 +569,13 @@ export function PaymentCalendar() {
         await updateCardAvailableCredit(instance.cardId, amountBeingPaid, 'add');
       }
 
+      syncUpdatedInstance(instance, {
+        status: 'paid',
+        paidDate: new Date(),
+        paidAmount: instance.amount,
+        remainingAmount: 0,
+      });
       toast.success('Pago marcado como realizado');
-      await refreshInstances();
     } catch (error) {
       console.error('Error marking as paid:', error);
       toast.error('Error al marcar como pagado');
@@ -565,8 +594,8 @@ export function PaymentCalendar() {
         updatedByName: currentUser.name,
       });
 
+      syncUpdatedInstance(instance, { status: 'cancelled' });
       toast.success('Pago cancelado');
-      await refreshInstances();
     } catch (error) {
       console.error('Error cancelling payment:', error);
       toast.error('Error al cancelar el pago');
@@ -601,6 +630,12 @@ export function PaymentCalendar() {
           updatedBy: currentUser.id,
           updatedByName: currentUser.name,
         });
+        syncUpdatedInstance(instance, {
+          status: 'partial',
+          paidDate: undefined,
+          paidAmount: totalPaid,
+          remainingAmount: remaining,
+        });
         toast.success('Pago marcado como parcial');
       } else {
         // Si no hay pagos parciales, marcar como pendiente
@@ -613,6 +648,12 @@ export function PaymentCalendar() {
           updatedBy: currentUser.id,
           updatedByName: currentUser.name,
         });
+        syncUpdatedInstance(instance, {
+          status: 'pending',
+          paidDate: undefined,
+          paidAmount: undefined,
+          remainingAmount: instance.amount,
+        });
         toast.success('Pago marcado como pendiente');
       }
 
@@ -620,8 +661,6 @@ export function PaymentCalendar() {
       if (instance.paymentType === 'card_payment' && instance.cardId && amountToRevert > 0) {
         await updateCardAvailableCredit(instance.cardId, amountToRevert, 'subtract');
       }
-
-      await refreshInstances();
     } catch (error) {
       console.error('Error unmarking as paid:', error);
       toast.error('Error al desmarcar como pagado');
@@ -693,6 +732,15 @@ export function PaymentCalendar() {
 
       await updateDoc(doc(db, 'payment_instances', editingInstance.id), updateData);
 
+      syncUpdatedInstance(editingInstance, {
+        amount: newAmount,
+        remainingAmount: Math.max(0, newRemainingAmount),
+        status: newStatus,
+        notes: adjustNotes || undefined,
+        paidAmount: newStatus === 'pending' ? undefined : newPaidAmount,
+        paidDate: newStatus === 'paid' ? new Date() : editingInstance.paidDate,
+      });
+
       if (newStatus === 'paid' && editingInstance.status !== 'paid') {
         toast.success('Los anticipos cubrieron el monto ajustado. Pago marcado como completado.');
       } else {
@@ -700,7 +748,6 @@ export function PaymentCalendar() {
       }
       setShowAdjustModal(false);
       setEditingInstance(null);
-      await refreshInstances();
     } catch (error) {
       console.error('Error adjusting amount:', error);
       toast.error('Error al ajustar el monto');
@@ -766,6 +813,14 @@ export function PaymentCalendar() {
         await updateCardAvailableCredit(editingInstance.cardId, amountToPay, 'add');
       }
 
+      syncUpdatedInstance(editingInstance, {
+        status: isFullyPaid ? 'paid' : 'partial',
+        paidAmount: newPaidAmount,
+        remainingAmount: newRemainingAmount,
+        partialPayments: [...(editingInstance.partialPayments || []), newPartialPayment],
+        paidDate: isFullyPaid ? new Date() : editingInstance.paidDate,
+      });
+
       toast.success(
         isFullyPaid
           ? 'Pago completado'
@@ -776,7 +831,6 @@ export function PaymentCalendar() {
       setEditingInstance(null);
       setPartialAmount('');
       setPartialNotes('');
-      await refreshInstances();
     } catch (error) {
       console.error('Error saving partial payment:', error);
       toast.error('Error al registrar el pago parcial');
@@ -831,8 +885,15 @@ export function PaymentCalendar() {
         await updateCardAvailableCredit(instance.cardId, payment.amount, 'subtract');
       }
 
+      syncUpdatedInstance(instance, {
+        status: newPaidAmount === 0 ? 'pending' : 'partial',
+        paidAmount: newPaidAmount === 0 ? undefined : newPaidAmount,
+        remainingAmount: newRemainingAmount,
+        partialPayments: updatedPartialPayments,
+        paidDate: newPaidAmount === 0 ? undefined : instance.paidDate,
+      });
+
       toast.success('Pago parcial eliminado');
-      await refreshInstances();
     } catch (error: any) {
       console.error('Error deleting partial payment:', error);
 
@@ -857,8 +918,15 @@ export function PaymentCalendar() {
             await updateCardAvailableCredit(instance.cardId, instance.paidAmount, 'subtract');
           }
 
+          syncUpdatedInstance(instance, {
+            status: 'pending',
+            paidAmount: undefined,
+            remainingAmount: instance.amount,
+            partialPayments: [],
+            paidDate: undefined,
+          });
+
           toast.success('Pagos parciales limpiados (formato antiguo incompatible)');
-          await refreshInstances();
           return;
         } catch (cleanupError) {
           console.error('Error cleaning up partial payments:', cleanupError);


### PR DESCRIPTION
## Summary
- Agrega `upsertPaymentInstance` al `DataContext` para actualizar instancias en memoria sin re-leer Firestore
- En `Cards.tsx`, reemplaza `fetchCardPayments()` post-mutación con `upsertCardPayment()` local
- En `PaymentCalendar.tsx`, elimina `refreshInstances()` y usa `syncUpdatedInstance()` para aplicar cambios optimistas tanto en estado local como en contexto global

## Test plan
- [ ] Marcar pago como pagado en Cards y verificar que la UI se actualiza sin delay
- [ ] Registrar pago parcial en Cards y verificar estado correcto
- [ ] Eliminar pago parcial en Cards y verificar rollback visual
- [ ] Marcar como pagado/cancelado/pendiente en Calendar y verificar actualización inmediata
- [ ] Ajustar monto en Calendar y verificar estado correcto
- [ ] Registrar/eliminar pago parcial en Calendar
- [ ] Verificar en Network tab que no hay lecturas adicionales a Firestore tras mutaciones

🤖 Generated with [Claude Code](https://claude.com/claude-code)