### PR TITLE
Fix hosting cache for app shell

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,6 +19,24 @@
     ],
     "headers": [
       {
+        "source": "/",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
         "source": "**/*.@(jpg|jpeg|gif|png|svg|webp)",
         "headers": [
           {


### PR DESCRIPTION
Sets Cache-Control: no-cache on the Firebase Hosting app shell so clients revalidate index.html and stop loading stale JS bundles after deploys.