### PR TITLE
Perf: throttle payment instance generation

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -93,6 +93,10 @@ interface PaymentInstanceInput {
   updatedByName: string;
 }
 
+interface EnsurePaymentInstancesData {
+  force?: boolean;
+}
+
 interface PhysicalCardResponse {
   label: string;
   lastDigitsPhysical: string | null;
@@ -132,6 +136,12 @@ function getDateKey(date: Date): string {
 
 function getPaymentInstanceDocId(scheduledPaymentId: string, dueDate: Date): string {
   return `${scheduledPaymentId}_${getDateKey(dueDate)}`;
+}
+
+function getPaymentGenerationKey(referenceDate = new Date()): string {
+  const currentMonth = getCurrentMonthRange(referenceDate);
+  const nextMonth = getNextMonthRange(referenceDate);
+  return `${getDateKey(currentMonth.start)}_${getDateKey(nextMonth.end)}`;
 }
 
 function getCurrentMonthRange(referenceDate = new Date()): { start: Date; end: Date } {
@@ -344,7 +354,7 @@ function isAlreadyExistsError(error: unknown): boolean {
   );
 }
 
-export const ensurePaymentInstances = functions.https.onCall(async (_data, context) => {
+export const ensurePaymentInstances = functions.https.onCall(async (data: EnsurePaymentInstancesData | undefined, context) => {
   if (!context.auth) {
     throw new functions.https.HttpsError('unauthenticated', 'Authentication required');
   }
@@ -352,6 +362,24 @@ export const ensurePaymentInstances = functions.https.onCall(async (_data, conte
   const householdId = context.auth.token.householdId as string | undefined;
   if (!householdId) {
     throw new functions.https.HttpsError('failed-precondition', 'Missing householdId claim');
+  }
+
+  const force = data?.force === true;
+  const generationKey = getPaymentGenerationKey();
+  const generationStateRef = db.collection('payment_instance_generation_state').doc(householdId);
+  const generationState = await generationStateRef.get();
+
+  if (!force && generationState.exists) {
+    const state = generationState.data();
+    if (state?.generationKey === generationKey && state?.version === 1) {
+      return {
+        success: true,
+        skipped: true,
+        checkedCount: 0,
+        createdCount: 0,
+        existingCount: 0,
+      };
+    }
   }
 
   const [scheduledSnapshot, servicesSnapshot, serviceLinesSnapshot] = await Promise.all([
@@ -430,8 +458,20 @@ export const ensurePaymentInstances = functions.https.onCall(async (_data, conte
     }
   }));
 
+  await generationStateRef.set({
+    householdId,
+    generationKey,
+    version: 1,
+    checkedCount: expectedInstances.length,
+    createdCount,
+    existingCount,
+    force,
+    completedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
+
   return {
     success: true,
+    skipped: false,
     checkedCount: expectedInstances.length,
     createdCount,
     existingCount,

--- a/src/lib/serverPaymentInstances.ts
+++ b/src/lib/serverPaymentInstances.ts
@@ -3,16 +3,21 @@ import { functions } from './firebase';
 
 interface EnsurePaymentInstancesResult {
   success: boolean;
+  skipped?: boolean;
   checkedCount: number;
   createdCount: number;
   existingCount: number;
 }
 
-export async function ensurePaymentInstances(): Promise<EnsurePaymentInstancesResult> {
-  const callable = httpsCallable<undefined, EnsurePaymentInstancesResult>(
+interface EnsurePaymentInstancesOptions {
+  force?: boolean;
+}
+
+export async function ensurePaymentInstances(options?: EnsurePaymentInstancesOptions): Promise<EnsurePaymentInstancesResult> {
+  const callable = httpsCallable<EnsurePaymentInstancesOptions | undefined, EnsurePaymentInstancesResult>(
     functions,
     'ensurePaymentInstances'
   );
-  const result = await callable(undefined);
+  const result = await callable(options);
   return result.data;
 }

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -472,7 +472,7 @@ export function Payments() {
         }
 
         // Luego generar nuevas instancias si faltan
-        await ensurePaymentInstances();
+        await ensurePaymentInstances({ force: true });
         console.log('[Payments] Instancias generadas exitosamente');
       } catch (instanceError) {
         console.error('[Payments] Error generando instancias:', instanceError);


### PR DESCRIPTION
Reduces repeated Firestore reads by storing a monthly generation marker per household. Dashboard calls skip the heavy generation scan after the current and next month have already been checked, while payment edits still force generation so new scheduled payments create their instances.