### PR TITLE
Fix Firestore startup read reduction

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -95,6 +95,7 @@ interface PaymentInstanceInput {
 
 interface EnsurePaymentInstancesData {
   force?: boolean;
+  scheduledPaymentId?: string;
 }
 
 interface PhysicalCardResponse {
@@ -345,6 +346,87 @@ function mapServiceLine(
   return { id: doc.id, ...doc.data() } as ServiceLine;
 }
 
+function mapServiceDoc(
+  doc: admin.firestore.DocumentSnapshot<admin.firestore.DocumentData>
+): Service | null {
+  return doc.exists ? ({ id: doc.id, ...doc.data() } as Service) : null;
+}
+
+function mapServiceLineDoc(
+  doc: admin.firestore.DocumentSnapshot<admin.firestore.DocumentData>
+): ServiceLine | null {
+  return doc.exists ? ({ id: doc.id, ...doc.data() } as ServiceLine) : null;
+}
+
+async function fetchRelatedPaymentResources(
+  householdId: string,
+  scheduledPayments: ScheduledPayment[]
+): Promise<{ services: Map<string, Service>; serviceLines: Map<string, ServiceLine> }> {
+  const billingCyclePayments = scheduledPayments.filter(payment => payment.frequency === 'billing_cycle');
+  const serviceIds = Array.from(new Set(
+    billingCyclePayments
+      .map(payment => payment.serviceId)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  ));
+  const serviceLineIds = Array.from(new Set(
+    billingCyclePayments
+      .map(payment => payment.serviceLineId)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  ));
+
+  const [serviceSnapshots, serviceLineSnapshots] = await Promise.all([
+    Promise.all(serviceIds.map(id => db.collection('services').doc(id).get())),
+    Promise.all(serviceLineIds.map(id => db.collection('service_lines').doc(id).get())),
+  ]);
+
+  const services = new Map<string, Service>();
+  serviceSnapshots.forEach(snapshot => {
+    const service = mapServiceDoc(snapshot);
+    const serviceHouseholdId = snapshot.data()?.householdId;
+    if (service && (!serviceHouseholdId || serviceHouseholdId === householdId)) {
+      services.set(service.id, service);
+    }
+  });
+
+  const serviceLines = new Map<string, ServiceLine>();
+  serviceLineSnapshots.forEach(snapshot => {
+    const serviceLine = mapServiceLineDoc(snapshot);
+    const serviceLineHouseholdId = snapshot.data()?.householdId;
+    if (serviceLine && (!serviceLineHouseholdId || serviceLineHouseholdId === householdId)) {
+      serviceLines.set(serviceLine.id, serviceLine);
+    }
+  });
+
+  return { services, serviceLines };
+}
+
+async function getExistingKeysForScheduledPayment(
+  householdId: string,
+  scheduledPaymentId: string
+): Promise<Set<string>> {
+  const currentMonth = getCurrentMonthRange();
+  const nextMonth = getNextMonthRange();
+  const existingSnapshot = await db
+    .collection('payment_instances')
+    .where('householdId', '==', householdId)
+    .where('scheduledPaymentId', '==', scheduledPaymentId)
+    .where('dueDate', '>=', admin.firestore.Timestamp.fromDate(currentMonth.start))
+    .where('dueDate', '<=', admin.firestore.Timestamp.fromDate(nextMonth.end))
+    .orderBy('dueDate', 'asc')
+    .get();
+
+  const existingKeys = new Set<string>();
+  existingSnapshot.docs.forEach(doc => {
+    const docData = doc.data();
+    const dueDate = toDate(docData.dueDate);
+    if (typeof docData.scheduledPaymentId === 'string' && dueDate) {
+      existingKeys.add(getPaymentInstanceDocId(docData.scheduledPaymentId, dueDate));
+    }
+  });
+
+  return existingKeys;
+}
+
 function isAlreadyExistsError(error: unknown): boolean {
   return (
     typeof error === 'object' &&
@@ -365,40 +447,71 @@ export const ensurePaymentInstances = functions.https.onCall(async (data: Ensure
   }
 
   const force = data?.force === true;
+  const scheduledPaymentId = typeof data?.scheduledPaymentId === 'string'
+    ? data.scheduledPaymentId.trim()
+    : '';
   const generationKey = getPaymentGenerationKey();
   const generationStateRef = db.collection('payment_instance_generation_state').doc(householdId);
-  const generationState = await generationStateRef.get();
 
-  if (!force && generationState.exists) {
-    const state = generationState.data();
-    if (state?.generationKey === generationKey && state?.version === 1) {
-      return {
-        success: true,
-        skipped: true,
-        checkedCount: 0,
-        createdCount: 0,
-        existingCount: 0,
-      };
+  if (!scheduledPaymentId) {
+    const generationState = await generationStateRef.get();
+
+    if (!force && generationState.exists) {
+      const state = generationState.data();
+      if (state?.generationKey === generationKey && state?.version === 1) {
+        return {
+          success: true,
+          skipped: true,
+          checkedCount: 0,
+          createdCount: 0,
+          existingCount: 0,
+        };
+      }
     }
   }
 
-  const [scheduledSnapshot, servicesSnapshot, serviceLinesSnapshot] = await Promise.all([
-    db.collection('scheduled_payments').where('householdId', '==', householdId).get(),
-    db.collection('services').where('householdId', '==', householdId).get(),
-    db.collection('service_lines').where('householdId', '==', householdId).get(),
-  ]);
+  let scheduledPayments: ScheduledPayment[];
+  let services: Map<string, Service>;
+  let serviceLines: Map<string, ServiceLine>;
 
-  const scheduledPayments = scheduledSnapshot.docs
-    .map(mapScheduledPayment)
-    .filter(payment => payment.isActive);
-  const services = new Map(servicesSnapshot.docs.map(doc => {
-    const service = mapService(doc);
-    return [service.id, service];
-  }));
-  const serviceLines = new Map(serviceLinesSnapshot.docs.map(doc => {
-    const serviceLine = mapServiceLine(doc);
-    return [serviceLine.id, serviceLine];
-  }));
+  if (scheduledPaymentId) {
+    const scheduledDoc = await db.collection('scheduled_payments').doc(scheduledPaymentId).get();
+
+    if (!scheduledDoc.exists) {
+      throw new functions.https.HttpsError('not-found', 'Scheduled payment not found');
+    }
+
+    const payment = {
+      ...scheduledDoc.data(),
+      id: scheduledDoc.id,
+      paymentDate: toDate(scheduledDoc.data()?.paymentDate),
+    } as ScheduledPayment;
+
+    if (payment.householdId !== householdId) {
+      throw new functions.https.HttpsError('permission-denied', 'Scheduled payment belongs to another household');
+    }
+
+    scheduledPayments = payment.isActive ? [payment] : [];
+    ({ services, serviceLines } = await fetchRelatedPaymentResources(householdId, scheduledPayments));
+  } else {
+    const [scheduledSnapshot, servicesSnapshot, serviceLinesSnapshot] = await Promise.all([
+      db.collection('scheduled_payments').where('householdId', '==', householdId).get(),
+      db.collection('services').where('householdId', '==', householdId).get(),
+      db.collection('service_lines').where('householdId', '==', householdId).get(),
+    ]);
+
+    scheduledPayments = scheduledSnapshot.docs
+      .map(mapScheduledPayment)
+      .filter(payment => payment.isActive);
+    services = new Map(servicesSnapshot.docs.map(doc => {
+      const service = mapService(doc);
+      return [service.id, service];
+    }));
+    serviceLines = new Map(serviceLinesSnapshot.docs.map(doc => {
+      const serviceLine = mapServiceLine(doc);
+      return [serviceLine.id, serviceLine];
+    }));
+  }
 
   const expectedInstances = scheduledPayments.flatMap(payment => {
     if (payment.frequency === 'billing_cycle' && !payment.paymentDate) {
@@ -411,24 +524,30 @@ export const ensurePaymentInstances = functions.https.onCall(async (data: Ensure
       payment.serviceLineId ? serviceLines.get(payment.serviceLineId) : undefined
     );
   });
-  const currentMonth = getCurrentMonthRange();
-  const nextMonth = getNextMonthRange();
-  const existingSnapshot = await db
-    .collection('payment_instances')
-    .where('householdId', '==', householdId)
-    .where('dueDate', '>=', admin.firestore.Timestamp.fromDate(currentMonth.start))
-    .where('dueDate', '<=', admin.firestore.Timestamp.fromDate(nextMonth.end))
-    .orderBy('dueDate', 'asc')
-    .get();
+  let existingKeys: Set<string>;
 
-  const existingKeys = new Set<string>();
-  existingSnapshot.docs.forEach(doc => {
-    const data = doc.data();
-    const dueDate = toDate(data.dueDate);
-    if (typeof data.scheduledPaymentId === 'string' && dueDate) {
-      existingKeys.add(getPaymentInstanceDocId(data.scheduledPaymentId, dueDate));
-    }
-  });
+  if (scheduledPaymentId) {
+    existingKeys = await getExistingKeysForScheduledPayment(householdId, scheduledPaymentId);
+  } else {
+    const currentMonth = getCurrentMonthRange();
+    const nextMonth = getNextMonthRange();
+    const existingSnapshot = await db
+      .collection('payment_instances')
+      .where('householdId', '==', householdId)
+      .where('dueDate', '>=', admin.firestore.Timestamp.fromDate(currentMonth.start))
+      .where('dueDate', '<=', admin.firestore.Timestamp.fromDate(nextMonth.end))
+      .orderBy('dueDate', 'asc')
+      .get();
+
+    existingKeys = new Set<string>();
+    existingSnapshot.docs.forEach(doc => {
+      const docData = doc.data();
+      const dueDate = toDate(docData.dueDate);
+      if (typeof docData.scheduledPaymentId === 'string' && dueDate) {
+        existingKeys.add(getPaymentInstanceDocId(docData.scheduledPaymentId, dueDate));
+      }
+    });
+  }
   const missingInstances = expectedInstances.filter(
     instance => !existingKeys.has(getPaymentInstanceDocId(instance.scheduledPaymentId, instance.dueDate))
   );
@@ -458,16 +577,18 @@ export const ensurePaymentInstances = functions.https.onCall(async (data: Ensure
     }
   }));
 
-  await generationStateRef.set({
-    householdId,
-    generationKey,
-    version: 1,
-    checkedCount: expectedInstances.length,
-    createdCount,
-    existingCount,
-    force,
-    completedAt: admin.firestore.FieldValue.serverTimestamp(),
-  }, { merge: true });
+  if (!scheduledPaymentId) {
+    await generationStateRef.set({
+      householdId,
+      generationKey,
+      version: 1,
+      checkedCount: expectedInstances.length,
+      createdCount,
+      existingCount,
+      force,
+      completedAt: admin.firestore.FieldValue.serverTimestamp(),
+    }, { merge: true });
+  }
 
   return {
     success: true,

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -205,46 +205,65 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
   const [paymentInstances, setPaymentInstances] = useState<PaymentInstance[]>([]);
   const [loading, setLoading] = useState(true);
   const [errors, setErrors] = useState<Record<DataErrorKey, string | null>>(INITIAL_ERRORS);
+  const [listenersEnabled, setListenersEnabled] = useState(false);
 
   // Track instances generation by month key (e.g. "2026-03")
   // Se reinicia automáticamente al cambiar de mes, permitiendo regenerar instancias
   const instancesGeneratedForMonthRef = useRef<string | null>(null);
+  const hydratedCacheKeyRef = useRef<string | null>(null);
+  const previousHouseholdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!householdId) {
-      setCards([]);
-      setBanks([]);
-      setServices([]);
-      setServiceLines([]);
-      setScheduledPayments([]);
-      setPaymentInstances([]);
-      setLoading(false);
-      setErrors(INITIAL_ERRORS);
-      instancesGeneratedForMonthRef.current = null;
-      return;
-    }
-
-    setLoading(true);
+    if (previousHouseholdRef.current === householdId) return;
+    previousHouseholdRef.current = householdId;
+    hydratedCacheKeyRef.current = null;
     instancesGeneratedForMonthRef.current = null;
+    setListenersEnabled(false);
+
+    setCards([]);
+    setBanks([]);
+    setServices([]);
+    setServiceLines([]);
+    setScheduledPayments([]);
+    setPaymentInstances([]);
+    setErrors(INITIAL_ERRORS);
+    setLoading(Boolean(householdId));
+  }, [householdId]);
+
+  useEffect(() => {
+    if (!householdId || listenersEnabled) return;
 
     const { startDate, endDate } = getPaymentInstancesWindow();
-    const cachedStartupData = pathname === '/'
-      ? readStartupCache(householdId, startDate, endDate)
-      : null;
+    const cacheKey = getStartupCacheKey(householdId, startDate, endDate);
 
-    if (cachedStartupData) {
-      setCards(cachedStartupData.cards);
-      setBanks(cachedStartupData.banks);
-      setServices(cachedStartupData.services);
-      setServiceLines(cachedStartupData.serviceLines);
-      setScheduledPayments(cachedStartupData.scheduledPayments);
-      setPaymentInstances(cachedStartupData.paymentInstances);
-      setErrors(INITIAL_ERRORS);
-      setLoading(false);
-      instancesGeneratedForMonthRef.current = getCurrentMonthKey();
-      return;
+    if (pathname === '/') {
+      const cachedStartupData = readStartupCache(householdId, startDate, endDate);
+
+      if (cachedStartupData) {
+        if (hydratedCacheKeyRef.current !== cacheKey) {
+          setCards(cachedStartupData.cards);
+          setBanks(cachedStartupData.banks);
+          setServices(cachedStartupData.services);
+          setServiceLines(cachedStartupData.serviceLines);
+          setScheduledPayments(cachedStartupData.scheduledPayments);
+          setPaymentInstances(cachedStartupData.paymentInstances);
+          setErrors(INITIAL_ERRORS);
+          setLoading(false);
+          hydratedCacheKeyRef.current = cacheKey;
+        }
+        setListenersEnabled(true);
+        return;
+      }
     }
 
+    setListenersEnabled(true);
+  }, [householdId, listenersEnabled, pathname]);
+
+  useEffect(() => {
+    if (!householdId || !listenersEnabled) return;
+
+    setLoading(true);
+    const { startDate, endDate } = getPaymentInstancesWindow();
     const loaded = new Set<string>();
     const TOTAL = 6;
 
@@ -383,7 +402,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     ));
 
     return () => unsubs.forEach(unsub => unsub());
-  }, [householdId, pathname]);
+  }, [householdId, listenersEnabled]);
 
   const isInstancesGenerated = useCallback(() => {
     const now = new Date();

--- a/src/lib/serverPaymentInstances.ts
+++ b/src/lib/serverPaymentInstances.ts
@@ -11,6 +11,7 @@ interface EnsurePaymentInstancesResult {
 
 interface EnsurePaymentInstancesOptions {
   force?: boolean;
+  scheduledPaymentId?: string;
 }
 
 export async function ensurePaymentInstances(options?: EnsurePaymentInstancesOptions): Promise<EnsurePaymentInstancesResult> {

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -472,7 +472,7 @@ export function Payments() {
         }
 
         // Luego generar nuevas instancias si faltan
-        await ensurePaymentInstances({ force: true });
+        await ensurePaymentInstances({ force: true, scheduledPaymentId: savedPaymentId });
         console.log('[Payments] Instancias generadas exitosamente');
       } catch (instanceError) {
         console.error('[Payments] Error generando instancias:', instanceError);


### PR DESCRIPTION
## Summary
- Cache dashboard startup data locally to reduce initial Firestore listener reads.
- Keep listeners active after cache hydration so dashboard data still syncs.
- Limit payment instance generation after saving a scheduled payment to the saved payment only.
- Preserve duplicate prevention when edited instances keep an older document ID.

## Validation
- npm run build
- npm --prefix functions run build